### PR TITLE
86 fix color override in dio and reset color in console

### DIFF
--- a/packages/talker_dio_logger/lib/http_logs.dart
+++ b/packages/talker_dio_logger/lib/http_logs.dart
@@ -17,8 +17,8 @@ class HttpRequestLog extends TalkerLog {
   final TalkerDioLoggerSettings settings;
 
   @override
-  AnsiPen get pen => settings.requestPen ?? AnsiPen()
-    ..xterm(219);
+  AnsiPen get pen => settings.requestPen ?? (AnsiPen()
+    ..xterm(219));
 
   @override
   String get title => 'http-request';
@@ -53,8 +53,8 @@ class HttpResponseLog extends TalkerLog {
   final TalkerDioLoggerSettings settings;
 
   @override
-  AnsiPen get pen => settings.responsePen ?? AnsiPen()
-    ..xterm(46);
+  AnsiPen get pen => settings.responsePen ?? (AnsiPen()
+    ..xterm(46));
 
   @override
   String get title => 'http-response';
@@ -96,8 +96,8 @@ class HttpErrorLog extends TalkerLog {
   final TalkerDioLoggerSettings settings;
 
   @override
-  AnsiPen get pen => settings.errorPen ?? AnsiPen()
-    ..red();
+  AnsiPen get pen => settings.errorPen ?? (AnsiPen()
+    ..red());
 
   @override
   String get title => 'http-error';

--- a/packages/talker_logger/lib/src/talker_logger.dart
+++ b/packages/talker_logger/lib/src/talker_logger.dart
@@ -8,7 +8,7 @@ class TalkerLogger implements TalkerLoggerInterface {
     void Function(String message)? output,
   }) {
     // ignore: avoid_print
-    _output = output ?? (String message) => print(message);
+    _output = output ?? (String message) => message.split('\n').forEach(print);
     _filter = filter ?? LogLevelTalkerLoggerFilter(settings.level);
     ansiColorDisabled = false;
   }


### PR DESCRIPTION
- Fixes color override in dio logger. There was an operator precedence problem
- Fixes color reset in console. Flutters default `print` command cuts long strings and it is also removes reset command at the end