### PR TITLE
Updated README.md to show correct package name.

### DIFF
--- a/packages/talker_bloc_logger/README.md
+++ b/packages/talker_bloc_logger/README.md
@@ -30,7 +30,8 @@ dependencies:
 Just set **TalkerBlocObserver** as Bloc.observer field and it will work
 
 ```dart
-import 'package:talker_bloc_observer/talker_bloc_observer.dart';
+import 'package:talker_bloc_logger/talker_bloc_logger.dart';
+
 
 Bloc.observer = TalkerBlocObserver();
 ```
@@ -41,7 +42,7 @@ You can add your talker instance for TalkerDioLogger if your app already uses Ta
 In this case, all logs and errors will fall into your unified tracking system
 
 ```dart
-import 'package:talker_bloc_observer/talker_bloc_observer.dart';
+import 'package:talker_bloc_logger/talker_bloc_logger.dart';
 import 'package:talker/talker.dart';
 
 final talker = Talker();


### PR DESCRIPTION
Using the code shown meant that the observer couldn't be initialised in a flutter app as the package name and path were incorrect.

### Thanks a lot for contributing!<br>
Using the code shown meant that the observer couldn't be initialised in a flutter app as the package name and path were incorrect.
