### PR TITLE
Fix http-response logs. 

### DIFF
--- a/packages/talker_dio_logger/lib/dio_logs.dart
+++ b/packages/talker_dio_logger/lib/dio_logs.dart
@@ -67,7 +67,7 @@ class DioResponseLog extends TalkerLog {
 
     final responseMessage = response.statusMessage;
     final data = response.data;
-    final headers = response.requestOptions.headers;
+    final headers = response.headers.map;
 
     msg += '\nStatus: ${response.statusCode}';
 

--- a/packages/talker_dio_logger/test/logger_test.dart
+++ b/packages/talker_dio_logger/test/logger_test.dart
@@ -32,5 +32,22 @@ void main() {
       logger.onResponse(response, ResponseInterceptorHandler());
       expect(talker.history.last.message, logMessage);
     });
+
+    test('onResponse method should log http response headers', () {
+      logger = TalkerDioLogger(talker: talker, settings: TalkerDioLoggerSettings(
+        printResponseHeaders: true
+      ));
+      final options = RequestOptions(path: '/test');
+      final response = Response(requestOptions: options, statusCode: 200, headers: Headers()..add("HEADER",
+      "VALUE"));
+      logger.onResponse(response, ResponseInterceptorHandler());
+      expect(talker.history.last.generateTextMessage(), '[http-response] [GET] /test\n'
+          'Status: 200\n'
+          'Headers: {\n'
+          '  "header": [\n'
+          '    "VALUE"\n'
+          '  ]\n'
+          '}');
+    });
   });
 }


### PR DESCRIPTION
When printResponseHeaders is enabled DioRequstLog use request headers instead of response. This commit fix this problem

### Thanks a lot for contributing!<br>
Provide a description of your changes below
