### PR TITLE
fix(122): Stack trace is printed when throwing String

### DIFF
--- a/packages/talker/lib/src/models/talker_log.dart
+++ b/packages/talker/lib/src/models/talker_log.dart
@@ -46,7 +46,7 @@ class TalkerLog implements TalkerDataInterface {
   /// {@macro talker_data_generateTextMessage}
   @override
   String generateTextMessage() {
-    return '$displayTitleWithTime$message';
+    return '$displayTitleWithTime$message$displayStackTrace';
   }
 
   /// {@macro talker_data_time}


### PR DESCRIPTION
Fix for (https://github.com/Frezyx/talker/issues/122)

Adding stack trace to a print when throwing a String
