### PR TITLE
TalkerWrapper error loop fix

### DIFF
--- a/packages/talker_flutter/lib/src/ui/talker_wrapper/talker_wrapper.dart
+++ b/packages/talker_flutter/lib/src/ui/talker_wrapper/talker_wrapper.dart
@@ -63,7 +63,7 @@ class TalkerWrapper extends StatelessWidget {
   }
 
   static void showAlert(BuildContext context, Widget content) {
-    ScaffoldMessenger.of(context).showSnackBar(
+    ScaffoldMessenger.maybeOf(context)?.showSnackBar(
       SnackBar(
         margin: EdgeInsets.zero,
         behavior: SnackBarBehavior.floating,


### PR DESCRIPTION
When `ScaffoldMessenger` is not available for some reason (like when error is received on app startup), `TalkerWrapper.showAlert()` was throwing an error that itself could be routed to `talker`, causing an infinite error loop.

This PR fixes the issue above by not *requiring* the `ScaffoldMessenger` to exist above the `TalkerWrapper` at all times.