### PR TITLE
Pad minutes and seconds for DT formatter

### DIFF
--- a/packages/talker/lib/src/utils/time_formatter.dart
+++ b/packages/talker/lib/src/utils/time_formatter.dart
@@ -9,6 +9,9 @@ class TalkerDateTimeFormatter {
   /// Format ['HH:mm:s ms']
   String get timeAndSeconds {
     final d = date;
-    return '${d.hour}:${d.minute}:${d.second} ${d.millisecond}ms';
+    final minutesPadded = '${d.minute}'.padLeft(2, '0');
+    final secondsPadded = '${d.second}'.padLeft(2, '0');
+
+    return '${d.hour}:$minutesPadded:$secondsPadded ${d.millisecond}ms';
   }
 }

--- a/packages/talker/test/time_formatter_test.dart
+++ b/packages/talker/test/time_formatter_test.dart
@@ -1,0 +1,22 @@
+import 'package:talker/src/utils/time_formatter.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TalkerDateTimeFormatter', () {
+    test('Pads small minutes and seconds', () {
+      final formatter = TalkerDateTimeFormatter(
+        DateTime(2023, 10, 17, 1, 1, 1),
+      );
+
+      expect(formatter.timeAndSeconds, equals('1:01:01 0ms'));
+    });
+
+    test("Large minutes and seconds aren't padded", () {
+      final formatter = TalkerDateTimeFormatter(
+        DateTime(2023, 10, 17, 1, 59, 35),
+      );
+
+      expect(formatter.timeAndSeconds, equals('1:59:35 0ms'));
+    });
+  });
+}


### PR DESCRIPTION
It's convention to pad the units of time with a '0' if they're less than 10 which Talker is not doing and it makes it hard to read. I have added tests to prevent regression.
