### PR TITLE
Fix the overflow issue of 'Talker Monitor'.

### DIFF
--- a/packages/talker_flutter/lib/src/ui/talker_monitor/widgets/talker_monitor_card.dart
+++ b/packages/talker_flutter/lib/src/ui/talker_monitor/widgets/talker_monitor_card.dart
@@ -31,33 +31,37 @@ class TalkerMonitorCard extends StatelessWidget {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Row(
-              children: [
-                Icon(icon, color: color),
-                const SizedBox(width: 10),
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      title,
-                      style: TextStyle(
-                        color: color,
-                        fontSize: 16,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                    if (subtitle != null)
-                      Text(
-                        subtitle!,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 14,
+            Flexible(
+              child: Row(
+                children: [
+                  Icon(icon, color: color),
+                  const SizedBox(width: 10),
+                  Flexible(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          title,
+                          style: TextStyle(
+                            color: color,
+                            fontSize: 16,
+                            fontWeight: FontWeight.w700,
+                          ),
                         ),
-                      ),
-                    if (subtitleWidget != null) subtitleWidget!
-                  ],
-                ),
-              ],
+                        if (subtitle != null)
+                          Text(
+                            subtitle!,
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                            ),
+                          ),
+                        if (subtitleWidget != null) subtitleWidget!
+                      ],
+                    ),
+                  ),
+                ],
+              ),
             ),
             if (onTap != null)
               Icon(Icons.arrow_forward_ios_rounded, color: color),


### PR DESCRIPTION
When the text exceeds one line, the card will overflow, as shown in the photo.
![image](https://github.com/Frezyx/talker/assets/11615068/24c0d8c6-5bdb-472a-bdc3-867afc723e88)
