### PR TITLE
can bring your own errorHandler class

### DIFF
--- a/packages/talker/lib/src/talker.dart
+++ b/packages/talker/lib/src/talker.dart
@@ -25,6 +25,9 @@ class Talker {
   /// You can set your own [LoggerFormatter] [loggerFormatter]
   /// to format output of talker logs,
   ///
+  /// You can set your own [TalkerErrorHandler] [TalkerErrorHandler]
+  /// to handle talker logs errors,
+  ///
   /// You can add your own observer to handle errors and logs in other place
   /// [TalkerObserver] [observer],
   /// {@endtemplate}
@@ -33,12 +36,13 @@ class Talker {
     TalkerObserver? observer,
     TalkerSettings? settings,
     TalkerFilter? filter,
+    TalkerErrorHandler? errorHandler,
   }) {
     _filter = filter;
     this.settings = settings ?? TalkerSettings();
     _logger = logger ?? TalkerLogger();
     _observer = observer ?? const _DefaultTalkerObserver();
-    _errorHandler = TalkerErrorHandler(this.settings);
+    _errorHandler = errorHandler ?? TalkerErrorHandler(this.settings);
   }
 
   /// Fields can be setup in [configure()] method


### PR DESCRIPTION
Hello,

I implemented my own logs grouping system (I will be another contribution about that later), but I'm stock by the errorHandler which cannot be override, so the three Object (TalkerError, TalkerException and TalkerLog) that are created are on it, cannot be override too.

Now, if I want to override this part of the fonctionnality, I need to reimplemente many thing (_oberver, _handleErrorData, _talkerStreamController, ...), which is a lot of work for very little thing.

