### PR TITLE
add onCreate, onClose logs for talker_bloc_logger

### DIFF
--- a/packages/talker/lib/src/well_known_titles.dart
+++ b/packages/talker/lib/src/well_known_titles.dart
@@ -6,6 +6,8 @@ enum WellKnownTitles {
   httpResponse,
   blocEvent,
   blocTransition,
+  blocCreate,
+  blocClose,
   route,
 }
 
@@ -26,6 +28,10 @@ extension WellKnownTitlesExt on WellKnownTitles {
         return 'bloc-event';
       case WellKnownTitles.blocTransition:
         return 'bloc-transition';
+      case WellKnownTitles.blocCreate:
+        return 'bloc-create';
+      case WellKnownTitles.blocClose:
+        return 'bloc-close';
       case WellKnownTitles.route:
         return 'ROUTE';
     }

--- a/packages/talker_bloc_logger/lib/bloc_logs.dart
+++ b/packages/talker_bloc_logger/lib/bloc_logs.dart
@@ -104,3 +104,57 @@ class BlocChangeLog extends TalkerLog {
     return sb.toString();
   }
 }
+
+/// [Bloc] created log model
+class BlocCreateLog extends TalkerLog {
+  BlocCreateLog({
+    required this.bloc,
+  }) : super('${bloc.runtimeType} created');
+
+  final BlocBase bloc;
+
+  @override
+  AnsiPen get pen => AnsiPen()..xterm(8);
+
+  @override
+  String get title => WellKnownTitles.blocCreate.title;
+
+  @override
+  String generateTextMessage() {
+    return _createMessage();
+  }
+
+  String _createMessage() {
+    final sb = StringBuffer();
+    sb.write(displayTitleWithTime);
+    sb.write('\n$message');
+    return sb.toString();
+  }
+}
+
+/// [Bloc] closed log model
+class BlocCloseLog extends TalkerLog {
+  BlocCloseLog({
+    required this.bloc,
+  }) : super('${bloc.runtimeType} closed');
+
+  final BlocBase bloc;
+
+  @override
+  AnsiPen get pen => AnsiPen()..xterm(13);
+
+  @override
+  String get title => WellKnownTitles.blocClose.title;
+
+  @override
+  String generateTextMessage() {
+    return _createMessage();
+  }
+
+  String _createMessage() {
+    final sb = StringBuffer();
+    sb.write(displayTitleWithTime);
+    sb.write('\n$message');
+    return sb.toString();
+  }
+}

--- a/packages/talker_bloc_logger/lib/talker_bloc_logger_observer.dart
+++ b/packages/talker_bloc_logger/lib/talker_bloc_logger_observer.dart
@@ -82,10 +82,18 @@ class TalkerBlocObserver extends BlocObserver {
   @override
   void onCreate(BlocBase bloc) {
     super.onCreate(bloc);
+    if (!settings.enabled || !settings.printCreations) {
+      return;
+    }
+    _talker.logTyped(BlocCreateLog(bloc: bloc));
   }
 
   @override
   void onClose(BlocBase bloc) {
     super.onClose(bloc);
+    if (!settings.enabled || !settings.printClosings) {
+      return;
+    }
+    _talker.logTyped(BlocCloseLog(bloc: bloc));
   }
 }

--- a/packages/talker_bloc_logger/lib/talker_bloc_logger_settings.dart
+++ b/packages/talker_bloc_logger/lib/talker_bloc_logger_settings.dart
@@ -8,6 +8,8 @@ class TalkerBlocLoggerSettings {
     this.printChanges = false,
     this.printEventFullData = true,
     this.printStateFullData = true,
+    this.printCreations = false,
+    this.printClosings = false,
     this.transitionFilter,
     this.eventFilter,
   });
@@ -18,6 +20,8 @@ class TalkerBlocLoggerSettings {
   final bool printChanges;
   final bool printEventFullData;
   final bool printStateFullData;
+  final bool printCreations;
+  final bool printClosings;
   final bool Function(Bloc bloc, Transition transition)? transitionFilter;
   final bool Function(Bloc bloc, Object? event)? eventFilter;
 }


### PR DESCRIPTION
- Add logging for the **onCreate**, **onClose** methods for the **TalkerBlocObserver**
- Add **printCreations**, **printClosings** fields in **TalkerBlocLoggerSettings**
- Use well known titles for titles (WellKnownTitles.blocCreate.title and WellKnownTitles.blocClose.title)

![Screenshot 2023-11-30 at 23 41 59](https://github.com/Frezyx/talker/assets/101732768/5767a102-a4d0-48df-a769-712f8671df83)
