### PR TITLE
can bring your own history class

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_dio_logger: ^2.3.3
+  talker_dio_logger: ^2.3.4
 ```
 
 ### Usage
@@ -437,7 +437,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_bloc_logger: ^2.3.2
+  talker_bloc_logger: ^2.3.3
 ```
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Follow these steps to the coolest experience in error handling
 ### Add dependency
 ```yaml
 dependencies:
-  talker: ^3.1.6
+  talker: ^3.1.7
 ```
 
 ### Easy to use
@@ -218,7 +218,7 @@ Talker Flutter is an extension for the Dart Talker package that adds extra funct
 ### Add dependency
 ```yaml
 dependencies:
-  talker_flutter: ^3.5.6
+  talker_flutter: ^3.5.7
 ```
 
 ### Setup

--- a/packages/talker/CHANGELOG.md
+++ b/packages/talker/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.1.7
+- Add package utils export 
+
+Thanks to [Ppito](https://github.com/Ppito)
+
 # 3.1.6
 **talker_bloc_logger**
 - Add onCreate, onClose logs

--- a/packages/talker/lib/src/history.dart
+++ b/packages/talker/lib/src/history.dart
@@ -1,0 +1,35 @@
+import 'package:talker/talker.dart';
+
+class DefaultTalkerHistory implements TalkerHistory {
+  DefaultTalkerHistory(this.settings);
+
+  final TalkerSettings settings;
+
+  final _history = <TalkerDataInterface>[];
+
+  @override
+  List<TalkerDataInterface> get history => _history;
+
+  @override
+  void clean() {
+    if (settings.useHistory) {
+      _history.clear();
+    }
+  }
+
+  @override
+  void write(TalkerDataInterface data) {
+    if (settings.useHistory && settings.enabled) {
+      if (settings.maxHistoryItems <= _history.length) {
+        _history.removeAt(0);
+      }
+      _history.add(data);
+    }
+  }
+}
+
+abstract class TalkerHistory {
+  List<TalkerDataInterface> get history;
+  void clean();
+  void write(TalkerDataInterface data);
+}

--- a/packages/talker/lib/src/models/talker_data_interface.dart
+++ b/packages/talker/lib/src/models/talker_data_interface.dart
@@ -1,4 +1,3 @@
-import 'package:talker/src/utils/utils.dart';
 import 'package:talker/talker.dart';
 
 /// Base [Talker] Data transfer object

--- a/packages/talker/lib/src/talker.dart
+++ b/packages/talker/lib/src/talker.dart
@@ -27,6 +27,9 @@ class Talker {
   /// You can set your own [TalkerErrorHandler] [TalkerErrorHandler]
   /// to handle talker logs errors,
   ///
+  /// You can set your own [TalkerHistory] [TalkerHistory]
+  /// to historize talker logs,
+  ///
   /// You can add your own observer to handle errors and logs in other place
   /// [TalkerObserver] [observer],
   /// {@endtemplate}
@@ -36,12 +39,14 @@ class Talker {
     TalkerSettings? settings,
     TalkerFilter? filter,
     TalkerErrorHandler? errorHandler,
+    TalkerHistory? history,
   }) {
     _filter = filter;
     this.settings = settings ?? TalkerSettings();
     _logger = logger ?? TalkerLogger();
     _observer = observer ?? const _DefaultTalkerObserver();
     _errorHandler = errorHandler ?? TalkerErrorHandler(this.settings);
+    _history = history ?? DefaultTalkerHistory(this.settings);
   }
 
   /// Fields can be setup in [configure()] method
@@ -52,9 +57,9 @@ class Talker {
   late TalkerErrorHandler _errorHandler;
   late TalkerFilter? _filter;
   late TalkerObserver _observer;
+  late TalkerHistory _history;
 
   // final _fileManager = FileManager();
-  final _history = <TalkerDataInterface>[];
 
   /// Setup configuration of Talker
   ///
@@ -72,6 +77,12 @@ class Talker {
   ///
   /// Also you can set [settings] [TalkerSettings],
   ///
+  /// You can set your own [TalkerErrorHandler] [TalkerErrorHandler]
+  /// to handle talker logs errors,
+  ///
+  /// You can set your own [TalkerHistory] [TalkerHistory]
+  /// to historize talker logs,
+  ///
   /// You can add your own observer to handle errors and logs in other place
   /// [TalkerObserver] [observer],
   void configure({
@@ -79,6 +90,8 @@ class Talker {
     TalkerSettings? settings,
     TalkerObserver? observer,
     TalkerFilter? filter,
+    TalkerErrorHandler? errorHandler,
+    TalkerHistory? history,
   }) {
     if (filter != null) {
       _filter = filter;
@@ -88,6 +101,8 @@ class Talker {
     }
     _observer = observer ?? _observer;
     _logger = logger ?? _logger;
+    _errorHandler = errorHandler ?? TalkerErrorHandler(this.settings);
+    _history = history ?? DefaultTalkerHistory(this.settings);
   }
 
   final _talkerStreamController =
@@ -107,7 +122,7 @@ class Talker {
   /// occurred errors [TalkerError]s, exceptions [TalkerException]s
   /// and logs [TalkerLog]s that have been sent
 
-  List<TalkerDataInterface> get history => _history;
+  List<TalkerDataInterface> get history => _history.history;
 
   /// Handle common exceptions in your code
   /// [Object] [exception] - exception
@@ -324,11 +339,8 @@ class Talker {
   }
 
   /// Clear log history
-
   void cleanHistory() {
-    if (settings.useHistory) {
-      _history.clear();
-    }
+    _history.clean();
   }
 
   /// Method stops all [Talker] works
@@ -409,8 +421,7 @@ class Talker {
   }
 
   void _handleForOutputs(TalkerDataInterface data) {
-    _writeToHistory(data);
-    // _writeToFile(data);
+    _history.write(data);
   }
 
   //TODO: recreate file manager logic
@@ -419,15 +430,6 @@ class Talker {
   //     _fileManager.writeToLogFile(data.generateTextMessage());
   //   }
   // }
-
-  void _writeToHistory(TalkerDataInterface data) {
-    if (settings.useHistory && settings.enabled) {
-      if (settings.maxHistoryItems <= _history.length) {
-        _history.removeAt(0);
-      }
-      _history.add(data);
-    }
-  }
 
   bool _isApprovedByFilter(TalkerDataInterface data) {
     final approved = _filter?.filter(data) ?? true;

--- a/packages/talker/lib/src/talker.dart
+++ b/packages/talker/lib/src/talker.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:talker/src/utils/utils.dart';
 import 'package:talker/talker.dart';
 
 /// Talker - advanced exception handling and logging

--- a/packages/talker/lib/talker.dart
+++ b/packages/talker/lib/talker.dart
@@ -6,5 +6,6 @@ export 'src/models/models.dart';
 export 'src/observer.dart';
 export 'src/settings.dart';
 export 'src/talker.dart';
+export 'src/history.dart';
 export 'src/utils/utils.dart';
 export 'src/well_known_titles.dart';

--- a/packages/talker/lib/talker.dart
+++ b/packages/talker/lib/talker.dart
@@ -6,4 +6,5 @@ export 'src/models/models.dart';
 export 'src/observer.dart';
 export 'src/settings.dart';
 export 'src/talker.dart';
+export 'src/utils/utils.dart';
 export 'src/well_known_titles.dart';

--- a/packages/talker/pubspec.yaml
+++ b/packages/talker/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker
 description: Advanced error handler and logger package for flutter and dart. App monitoring, logs history, report sharing, custom logs, and etc.
-version: 3.1.6
+version: 3.1.7
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
 issue_tracker: https://github.com/Frezyx/talker/issues

--- a/packages/talker/test/talker_data_models_test.dart
+++ b/packages/talker/test/talker_data_models_test.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: unnecessary_type_check, leading_newlines_in_multiline_strings
 
-import 'package:talker/src/utils/utils.dart';
 import 'package:talker/talker.dart';
 import 'package:test/test.dart';
 

--- a/packages/talker/test/talker_error_handler_test.dart
+++ b/packages/talker/test/talker_error_handler_test.dart
@@ -1,4 +1,3 @@
-import 'package:talker/src/utils/utils.dart';
 import 'package:talker/talker.dart';
 import 'package:test/test.dart';
 

--- a/packages/talker_bloc_logger/CHANGELOG.md
+++ b/packages/talker_bloc_logger/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.3
+- Update **talker** version to 3.1.7
+
 ## 2.3.2
 - Update **talker** version to 3.1.6
 - Fix last deploy issues (Member not found for WellKnownTitles issue)

--- a/packages/talker_bloc_logger/README.md
+++ b/packages/talker_bloc_logger/README.md
@@ -23,7 +23,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_bloc_logger: ^2.3.2
+  talker_bloc_logger: ^2.3.3
 ```
 
 ### Usage

--- a/packages/talker_bloc_logger/pubspec.yaml
+++ b/packages/talker_bloc_logger/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
   sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
-  talker: ^3.1.6
+  talker: ^3.1.7
   bloc: ^8.1.1
   meta: ^1.8.0
 

--- a/packages/talker_bloc_logger/pubspec.yaml
+++ b/packages/talker_bloc_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_bloc_logger
 description: Lightweight and customizable BLoC state management library logger on talker base.
-version: 2.3.2
+version: 2.3.3
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
 issue_tracker: https://github.com/Frezyx/talker/issues

--- a/packages/talker_dio_logger/CHANGELOG.md
+++ b/packages/talker_dio_logger/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.4
+- Update **talker** version to 3.1.7
+
 ## 2.3.3
 - Update **talker** version to 3.1.6
 

--- a/packages/talker_dio_logger/README.md
+++ b/packages/talker_dio_logger/README.md
@@ -23,7 +23,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_dio_logger: ^2.3.3
+  talker_dio_logger: ^2.3.4
 ```
 
 ### Usage

--- a/packages/talker_dio_logger/example/pubspec.lock
+++ b/packages/talker_dio_logger/example/pubspec.lock
@@ -321,10 +321,10 @@ packages:
     dependency: transitive
     description:
       name: talker
-      sha256: "447411fbc819b5cc41b647d4134d18535bec50616c45ce78b451abd37a22cc91"
+      sha256: "3cb5741a36032c64a16f06e715c7d74a65279f6e7e87b1f939ddfe027cb2fcfe"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.6"
+    version: "3.1.7"
   talker_dio_logger:
     dependency: "direct main"
     description:
@@ -337,10 +337,10 @@ packages:
     dependency: "direct main"
     description:
       name: talker_flutter
-      sha256: "0b410c49edb50dd6a9ea2ddb049f547aa699907e90129ec024e5eae555ad34d5"
+      sha256: "7705d4cd65e700f4c5946b5891e67a4c230eb79cdd7e4db1bfe02bb62edc56c8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.6"
+    version: "3.5.7"
   talker_logger:
     dependency: transitive
     description:

--- a/packages/talker_dio_logger/example/pubspec.yaml
+++ b/packages/talker_dio_logger/example/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
     sdk: flutter
   dio: ^5.0.0
   talker_dio_logger: ^2.3.1
-  talker_flutter: ^3.5.6    
+  talker_flutter: ^3.5.7    
 
 dev_dependencies:
   flutter_test:

--- a/packages/talker_dio_logger/pubspec.yaml
+++ b/packages/talker_dio_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_dio_logger
 description: Lightweight and customizable dio http client logger on talker base
-version: 2.3.3
+version: 2.3.4
 
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker

--- a/packages/talker_dio_logger/pubspec.yaml
+++ b/packages/talker_dio_logger/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
 
 dependencies:
   dio: ^5.2.0
-  talker: ^3.1.6
+  talker: ^3.1.7
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/talker_flutter/CHANGELOG.md
+++ b/packages/talker_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 3.5.7
+- Add package utils export 
+
+Thanks to [Ppito](https://github.com/Ppito)
+
 # 3.5.6
 **talker_bloc_logger**
 - Add onCreate, onClose logs

--- a/packages/talker_flutter/pubspec.yaml
+++ b/packages/talker_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_flutter
 description: Advanced error handler and logger package for flutter and dart. App monitoring, logs history, report sharing, custom logs, and etc.
-version: 3.5.6
+version: 3.5.7
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
 issue_tracker: https://github.com/Frezyx/talker/issues
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  talker: ^3.1.6
+  talker: ^3.1.7
   group_button: ^5.3.3
   path_provider: ^2.1.1
   share_plus: ^7.2.1


### PR DESCRIPTION
Hello @Frezyx,

I need to monitor my application and keep the log history to do some stuff on it. (Like, to bring back all the logs for our support operations).
So I've moved the logic of your history implementation into a class that I can override like I want.

By the way, I saw that you were thinking about a FileManager implementation, and I think we could use this approach. What do you thinks ?

And by extension, why not offer log history implementations directly with Isar, hive or SQFlite database?

In any case, by passing through a class we'll be free to make our own implementation of the history backup.
