### PR TITLE
fix(utils): add missing export file

### DIFF
--- a/packages/talker/lib/src/models/talker_data_interface.dart
+++ b/packages/talker/lib/src/models/talker_data_interface.dart
@@ -1,4 +1,3 @@
-import 'package:talker/src/utils/utils.dart';
 import 'package:talker/talker.dart';
 
 /// Base [Talker] Data transfer object

--- a/packages/talker/lib/src/talker.dart
+++ b/packages/talker/lib/src/talker.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:talker/src/utils/utils.dart';
 import 'package:talker/talker.dart';
 
 /// Talker - advanced exception handling and logging

--- a/packages/talker/lib/talker.dart
+++ b/packages/talker/lib/talker.dart
@@ -6,4 +6,5 @@ export 'src/models/models.dart';
 export 'src/observer.dart';
 export 'src/settings.dart';
 export 'src/talker.dart';
+export 'src/utils/utils.dart';
 export 'src/well_known_titles.dart';

--- a/packages/talker/test/talker_data_models_test.dart
+++ b/packages/talker/test/talker_data_models_test.dart
@@ -1,6 +1,5 @@
 // ignore_for_file: unnecessary_type_check, leading_newlines_in_multiline_strings
 
-import 'package:talker/src/utils/utils.dart';
 import 'package:talker/talker.dart';
 import 'package:test/test.dart';
 

--- a/packages/talker/test/talker_error_handler_test.dart
+++ b/packages/talker/test/talker_error_handler_test.dart
@@ -1,4 +1,3 @@
-import 'package:talker/src/utils/utils.dart';
 import 'package:talker/talker.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
Hi @Frezyx,

I forgot to export the `utils` file, on #161. 