### PR TITLE
Fix inconsistent colors

### DIFF
--- a/.vscode/talker.code-workspace
+++ b/.vscode/talker.code-workspace
@@ -1,0 +1,28 @@
+{
+    "folders": [
+        {
+            "name": "talker",
+            "path": "../packages/talker"
+        },
+        {
+            "name": "talker_bloc_logger",
+            "path": "../packages/talker_bloc_logger"
+        },
+        {
+            "name": "talker_dio_logger",
+            "path": "../packages/talker_dio_logger"
+        },
+        {
+            "name": "talker_flutter",
+            "path": "../packages/talker_flutter"
+        },
+        {
+            "name": "talker_http_logger",
+            "path": "../packages/talker_http_logger"
+        },
+        {
+            "name": "talker_logger",
+            "path": "../packages/talker_logger"
+        }
+    ]
+}

--- a/packages/talker_dio_logger/example/pubspec.lock
+++ b/packages/talker_dio_logger/example/pubspec.lock
@@ -321,7 +321,7 @@ packages:
     dependency: transitive
     description:
       name: talker
-      sha256: "0275b2453b7b52bfb4b3dc9b967048b2af810ce700448d8574bf1fa80cec0e97"
+      sha256: "2cabd27c08f2036f62c5cd9588579484c53de5273677563b69ca3a83bac6aa37"
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
@@ -343,7 +343,7 @@ packages:
     dependency: transitive
     description:
       name: talker_logger
-      sha256: edcf098c16e0b1ce7fc772e689908a8bb2a431b7fc2d487d7579dad899326560
+      sha256: "426d439c0232cad96fc0291cfcc5fe83c8429a4befc00c1bbb8cd923c7e23543"
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"

--- a/packages/talker_flutter/example/pubspec.lock
+++ b/packages/talker_flutter/example/pubspec.lock
@@ -313,7 +313,7 @@ packages:
     dependency: transitive
     description:
       name: talker
-      sha256: "0275b2453b7b52bfb4b3dc9b967048b2af810ce700448d8574bf1fa80cec0e97"
+      sha256: "2cabd27c08f2036f62c5cd9588579484c53de5273677563b69ca3a83bac6aa37"
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
@@ -328,7 +328,7 @@ packages:
     dependency: transitive
     description:
       name: talker_logger
-      sha256: edcf098c16e0b1ce7fc772e689908a8bb2a431b7fc2d487d7579dad899326560
+      sha256: "426d439c0232cad96fc0291cfcc5fe83c8429a4befc00c1bbb8cd923c7e23543"
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"

--- a/packages/talker_flutter/lib/src/ui/talker_actions/talker_actions_bottom_sheet.dart
+++ b/packages/talker_flutter/lib/src/ui/talker_actions/talker_actions_bottom_sheet.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:talker_flutter/src/ui/theme/default_theme.dart';
 import 'package:talker_flutter/src/ui/widgets/bottom_sheet.dart';
 import 'package:talker_flutter/talker_flutter.dart';
 
@@ -21,7 +20,7 @@ class TalkerActionsBottomSheet extends StatelessWidget {
       child: Container(
         margin: const EdgeInsets.symmetric(horizontal: 16).copyWith(bottom: 16),
         decoration: BoxDecoration(
-          color: defaultCardBackgroundColor,
+          color: talkerScreenTheme.backgroundColor,
           borderRadius: BorderRadius.circular(16),
         ),
         child: Column(

--- a/packages/talker_flutter/lib/src/ui/talker_monitor/talker_monitor.dart
+++ b/packages/talker_flutter/lib/src/ui/talker_monitor/talker_monitor.dart
@@ -60,6 +60,7 @@ class TalkerMonitor extends StatelessWidget {
                     logs: httpRequests,
                     title: 'Http Requests',
                     color: Colors.green,
+                    theme: theme,
                     icon: Icons.wifi,
                     onTap: () => _openHttpMonitor(context),
                     subtitleWidget: Column(
@@ -107,6 +108,7 @@ class TalkerMonitor extends StatelessWidget {
                 const SliverToBoxAdapter(child: SizedBox(height: 10)),
                 SliverToBoxAdapter(
                   child: TalkerMonitorCard(
+                    theme: theme,
                     logs: errors,
                     title: 'Errors',
                     color: theme.logColors.getByType(TalkerLogType.error),
@@ -122,6 +124,7 @@ class TalkerMonitor extends StatelessWidget {
                 const SliverToBoxAdapter(child: SizedBox(height: 10)),
                 SliverToBoxAdapter(
                   child: TalkerMonitorCard(
+                    theme: theme,
                     logs: exceptions,
                     title: 'Exceptions',
                     color: theme.logColors.getByType(TalkerLogType.exception),
@@ -137,6 +140,7 @@ class TalkerMonitor extends StatelessWidget {
                 const SliverToBoxAdapter(child: SizedBox(height: 10)),
                 SliverToBoxAdapter(
                   child: TalkerMonitorCard(
+                    theme: theme,
                     logs: warnings,
                     title: 'Warnings',
                     color: theme.logColors.getByType(TalkerLogType.warning),
@@ -151,6 +155,7 @@ class TalkerMonitor extends StatelessWidget {
                 const SliverToBoxAdapter(child: SizedBox(height: 10)),
                 SliverToBoxAdapter(
                   child: TalkerMonitorCard(
+                    theme: theme,
                     logs: infos,
                     title: 'Infos',
                     color: theme.logColors.getByType(TalkerLogType.info),
@@ -164,6 +169,7 @@ class TalkerMonitor extends StatelessWidget {
                 const SliverToBoxAdapter(child: SizedBox(height: 10)),
                 SliverToBoxAdapter(
                   child: TalkerMonitorCard(
+                    theme: theme,
                     logs: verboseDebug,
                     title: 'Verbose & debug',
                     color: theme.logColors.getByType(TalkerLogType.verbose),

--- a/packages/talker_flutter/lib/src/ui/talker_monitor/talker_monitor_typed_logs_screen.dart
+++ b/packages/talker_flutter/lib/src/ui/talker_monitor/talker_monitor_typed_logs_screen.dart
@@ -32,6 +32,7 @@ class TalkerMonitorTypedLogsScreen extends StatelessWidget {
                   data: data,
                   onCopyTap: () => _copyTalkerDataItemText(context, data),
                   color: data.getFlutterColor(theme),
+                  backgroundColor: theme.cardColor,
                 );
               },
               childCount: exceptions.length,

--- a/packages/talker_flutter/lib/src/ui/talker_monitor/widgets/talker_monitor_card.dart
+++ b/packages/talker_flutter/lib/src/ui/talker_monitor/widgets/talker_monitor_card.dart
@@ -12,6 +12,7 @@ class TalkerMonitorCard extends StatelessWidget {
     required this.color,
     required this.icon,
     this.onTap,
+    required this.theme,
   }) : super(key: key);
 
   final String title;
@@ -21,6 +22,7 @@ class TalkerMonitorCard extends StatelessWidget {
   final Color color;
   final IconData icon;
   final VoidCallback? onTap;
+  final TalkerScreenTheme theme;
 
   @override
   Widget build(BuildContext context) {
@@ -28,6 +30,7 @@ class TalkerMonitorCard extends StatelessWidget {
       onTap: onTap,
       child: TalkerBaseCard(
         color: color,
+        backgroundColor: theme.backgroundColor,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
@@ -51,8 +54,8 @@ class TalkerMonitorCard extends StatelessWidget {
                         if (subtitle != null)
                           Text(
                             subtitle!,
-                            style: const TextStyle(
-                              color: Colors.white,
+                            style: TextStyle(
+                              color: theme.textColor,
                               fontSize: 14,
                             ),
                           ),

--- a/packages/talker_flutter/lib/src/ui/talker_settings/widgets/talker_setting_card.dart
+++ b/packages/talker_flutter/lib/src/ui/talker_settings/widgets/talker_setting_card.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:talker_flutter/src/ui/theme/default_theme.dart';
 import 'package:talker_flutter/src/ui/widgets/base_card.dart';
 import 'package:talker_flutter/talker_flutter.dart';
 
@@ -12,7 +11,6 @@ class TalkerSettingsCard extends StatelessWidget {
     required this.enabled,
     required this.onChanged,
     this.canEdit = true,
-    this.backgroundColor = defaultCardBackgroundColor,
   }) : super(key: key);
 
   final String title;
@@ -20,7 +18,6 @@ class TalkerSettingsCard extends StatelessWidget {
   final Function(bool enabled) onChanged;
   final TalkerScreenTheme talkerScreenTheme;
   final bool canEdit;
-  final Color backgroundColor;
 
   @override
   Widget build(BuildContext context) {
@@ -32,7 +29,8 @@ class TalkerSettingsCard extends StatelessWidget {
         child: TalkerBaseCard(
           padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8)
               .copyWith(right: 0),
-          color: backgroundColor,
+          color: talkerScreenTheme.textColor,
+          backgroundColor: talkerScreenTheme.cardColor,
           child: ListTile(
             title: Text(
               title,

--- a/packages/talker_flutter/lib/src/ui/theme/talker_screen_theme.dart
+++ b/packages/talker_flutter/lib/src/ui/theme/talker_screen_theme.dart
@@ -38,6 +38,7 @@ class TalkerScreenTheme {
       backgroundColor: theme.colorScheme.background,
       textColor: theme.colorScheme.onBackground,
       cardColor: theme.colorScheme.surface,
+      logColors: logColors,
     );
   }
 }

--- a/packages/talker_flutter/lib/src/ui/theme/talker_screen_theme.dart
+++ b/packages/talker_flutter/lib/src/ui/theme/talker_screen_theme.dart
@@ -49,7 +49,6 @@ extension MapTalkerFlutterColorsExt on LogColors {
   }
 }
 
-// 💡 why not merge this into
 const _defaultColors = {
   /// Base logs section
   TalkerLogType.error: Color.fromARGB(255, 239, 83, 80),

--- a/packages/talker_flutter/lib/src/ui/theme/talker_screen_theme.dart
+++ b/packages/talker_flutter/lib/src/ui/theme/talker_screen_theme.dart
@@ -2,13 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:talker_flutter/src/ui/theme/default_theme.dart';
 import 'package:talker_flutter/talker_flutter.dart';
 
+typedef LogColors = Map<TalkerLogType, Color>;
+
 /// Configuring the UI of [TalkerScreen]
 class TalkerScreenTheme {
   const TalkerScreenTheme({
     this.backgroundColor = const Color(0xFF212121),
     this.textColor = Colors.white,
     this.cardColor = defaultCardBackgroundColor,
-    Map<TalkerLogType, Color>? logColors,
+    LogColors? logColors,
   }) : _customColors = logColors;
 
   /// Background screen color
@@ -30,14 +32,23 @@ class TalkerScreenTheme {
     }
     return _defaultColors;
   }
+
+  factory TalkerScreenTheme.fromTheme(ThemeData theme, [LogColors? logColors]) {
+    return TalkerScreenTheme(
+      backgroundColor: theme.colorScheme.background,
+      textColor: theme.colorScheme.onBackground,
+      cardColor: theme.colorScheme.surface,
+    );
+  }
 }
 
-extension MapTalkerFlutterColorsExt on Map<TalkerLogType, Color> {
+extension MapTalkerFlutterColorsExt on LogColors {
   Color getByType(TalkerLogType type) {
     return this[type] ?? Colors.grey;
   }
 }
 
+// 💡 why not merge this into
 const _defaultColors = {
   /// Base logs section
   TalkerLogType.error: Color.fromARGB(255, 239, 83, 80),

--- a/packages/talker_flutter/lib/src/ui/widgets/talker_view_appbar.dart
+++ b/packages/talker_flutter/lib/src/ui/widgets/talker_view_appbar.dart
@@ -109,9 +109,10 @@ class TalkerViewAppBar extends StatelessWidget {
                           return Container(
                             padding: const EdgeInsets.all(8),
                             decoration: BoxDecoration(
+                              border: Border.all(color: talkerTheme.textColor),
                               borderRadius: BorderRadius.circular(10),
                               color: selected
-                                  ? theme.primaryColor
+                                  ? theme.colorScheme.primaryContainer
                                   : talkerTheme.cardColor,
                             ),
                             child: Row(
@@ -120,7 +121,6 @@ class TalkerViewAppBar extends StatelessWidget {
                                   '$count',
                                   style: const TextStyle(
                                     fontSize: 12,
-                                    color: Colors.white,
                                   ),
                                 ),
                                 const SizedBox(width: 4),
@@ -128,7 +128,6 @@ class TalkerViewAppBar extends StatelessWidget {
                                   '$value',
                                   style: const TextStyle(
                                     fontSize: 12,
-                                    color: Colors.white,
                                   ),
                                 ),
                               ],


### PR DESCRIPTION
### Thanks a lot for contributing!<br>

Found some more inconsistencies with the background and text colors, so fixed them.

Also added a factory to TalkerScreenTheme where you can just pass your ThemeData and optionally custom log colors.

In .vsocde I left my talker.code-workspace. I find this easy to use in a nested packages case.