### PR TITLE
enable mouse scroll

### DIFF
--- a/examples/shop_app_example/lib/main.dart
+++ b/examples/shop_app_example/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:talker_flutter/talker_flutter.dart';
 import 'package:talker_shop_app_example/repositories/products/products.dart';
 import 'package:talker_shop_app_example/ui/presentation_frame.dart';
 import 'package:talker_shop_app_example/ui/ui.dart';
+import 'package:talker_shop_app_example/utils/scroll_behavior.dart';
 import 'package:talker_shop_app_example/utils/utils.dart';
 
 import 'firebase_options.dart';
@@ -82,6 +83,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      scrollBehavior: WebScrollBehavior(),
       title: 'Talker shop app',
       theme: lightTheme,
       initialRoute: Routes.productsList,

--- a/examples/shop_app_example/lib/main.dart
+++ b/examples/shop_app_example/lib/main.dart
@@ -83,7 +83,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      scrollBehavior: WebScrollBehavior(),
+      scrollBehavior: kIsWeb ? WebScrollBehavior() : null,
       title: 'Talker shop app',
       theme: lightTheme,
       initialRoute: Routes.productsList,

--- a/examples/shop_app_example/lib/utils/scroll_behavior.dart
+++ b/examples/shop_app_example/lib/utils/scroll_behavior.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+/// This class is used to override the default scroll behavior of the
+/// [MaterialApp] widget.
+///
+/// The default scroll behavior of the [MaterialApp] widget is to only
+/// scroll when the user is using a touch device. This class overrides
+/// that behavior to allow scrolling when the user is using a mouse
+/// device.
+///
+/// This class is used in the [MaterialApp.scrollBehavior] property.
+///
+/// See: https://docs.flutter.dev/release/breaking-changes/default-scroll-behavior-drag
+class WebScrollBehavior extends MaterialScrollBehavior {
+  @override
+  Set<PointerDeviceKind> get dragDevices => {
+        PointerDeviceKind.touch,
+        PointerDeviceKind.mouse,
+        PointerDeviceKind.invertedStylus,
+        PointerDeviceKind.stylus,
+        PointerDeviceKind.trackpad,
+        PointerDeviceKind.unknown,
+      };
+}


### PR DESCRIPTION
With this change in the example app, the mouse can be used to scroll by dragging the elements which feels a bit more natural than scrolling by scroll wheel and also allows for horizontal scrolling. 