### PR TITLE
fix exception info missing

### DIFF
--- a/packages/talker/lib/src/models/talker_log.dart
+++ b/packages/talker/lib/src/models/talker_log.dart
@@ -18,6 +18,6 @@ class TalkerLog extends TalkerData {
   /// {@macro talker_data_generateTextMessage}
   @override
   String generateTextMessage() {
-    return '$displayTitleWithTime$displayMessage$displayStackTrace';
+    return '$displayTitleWithTime$displayMessage$displayException$displayStackTrace';
   }
 }


### PR DESCRIPTION
### Thanks a lot for contributing!<br>
Console logs missing exception info when using `talker.error('Message', exception, stackTrace)`.
Associated issue: https://github.com/Frezyx/talker/issues/205