### PR TITLE
Update share_plus to version 9

### DIFF
--- a/packages/talker_flutter/pubspec.yaml
+++ b/packages/talker_flutter/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   talker: ^4.1.4
   group_button: ^5.3.4
   path_provider: ^2.1.2
-  share_plus: ^8.0.2
+  share_plus: ^9.0.0
 
 
 dev_dependencies:


### PR DESCRIPTION
The latest version of `share_plus` introduces breaking changes, primarily the removal of obsolete modules. These changes do not impact `talker_flutter` as the removed methods were not in use.

This is to avoid version conflicts for projects that use both `share_plus` and `talker_flutter` and need to update to the latest versions of both