### PR TITLE
feat: add missing error setting for dio logger

### DIFF
--- a/packages/talker_dio_logger/example/lib/main.dart
+++ b/packages/talker_dio_logger/example/lib/main.dart
@@ -85,7 +85,7 @@ class _MyAppState extends State<MyApp> {
               ),
               ElevatedButton(
                 style: ButtonStyle(
-                  backgroundColor: MaterialStateProperty.all(Colors.red),
+                  backgroundColor: WidgetStateProperty.all(Colors.red),
                 ),
                 onPressed: () {
                   _dio.get('htt://jsonplaceholder.typicode.com/todos');

--- a/packages/talker_dio_logger/lib/dio_logs.dart
+++ b/packages/talker_dio_logger/lib/dio_logs.dart
@@ -119,13 +119,16 @@ class DioErrorLog extends TalkerLog {
     if (statusCode != null) {
       msg += '\nStatus: ${dioException.response?.statusCode}';
     }
-    msg += '\nMessage: $responseMessage';
 
-    if (data != null) {
+    if (settings.printErrorMessage && responseMessage != null) {
+      msg += '\nMessage: $responseMessage';
+    }
+
+    if (settings.printErrorData && data != null) {
       final prettyData = encoder.convert(data);
       msg += '\nData: $prettyData';
     }
-    if (!(headers?.isEmpty ?? true)) {
+    if (settings.printErrorHeaders && !(headers?.isEmpty ?? true)) {
       final prettyHeaders = encoder.convert(headers!.map);
       msg += '\nHeaders: $prettyHeaders';
     }

--- a/packages/talker_dio_logger/lib/talker_dio_logger_interceptor.dart
+++ b/packages/talker_dio_logger/lib/talker_dio_logger_interceptor.dart
@@ -31,6 +31,9 @@ class TalkerDioLogger extends Interceptor {
     bool? printResponseData,
     bool? printResponseHeaders,
     bool? printResponseMessage,
+    bool? printErrorData,
+    bool? printErrorHeaders,
+    bool? printErrorMessage,
     bool? printRequestData,
     bool? printRequestHeaders,
     AnsiPen? requestPen,
@@ -41,6 +44,9 @@ class TalkerDioLogger extends Interceptor {
       printRequestData: printRequestData,
       printRequestHeaders: printRequestHeaders,
       printResponseData: printResponseData,
+      printErrorData: printErrorData,
+      printErrorHeaders: printErrorHeaders,
+      printErrorMessage: printErrorMessage,
       printResponseHeaders: printResponseHeaders,
       printResponseMessage: printResponseMessage,
       requestPen: requestPen,
@@ -95,6 +101,10 @@ class TalkerDioLogger extends Interceptor {
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) {
     super.onError(err, handler);
+    final accepted = settings.errorFilter?.call(err) ?? true;
+    if (!accepted) {
+      return;
+    }
     try {
       final message = '${err.requestOptions.uri}';
       final httpErrorLog = DioErrorLog(

--- a/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
+++ b/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
@@ -7,6 +7,9 @@ class TalkerDioLoggerSettings {
     this.printResponseData = true,
     this.printResponseHeaders = false,
     this.printResponseMessage = true,
+    this.printErrorData = true,
+    this.printErrorHeaders = true,
+    this.printErrorMessage = true,
     this.printRequestData = true,
     this.printRequestHeaders = false,
     this.requestPen,
@@ -14,6 +17,7 @@ class TalkerDioLoggerSettings {
     this.errorPen,
     this.requestFilter,
     this.responseFilter,
+    this.errorFilter,
   });
 
   /// Print [response.data] if true
@@ -24,6 +28,15 @@ class TalkerDioLoggerSettings {
 
   /// Print [response.statusMessage] if true
   final bool printResponseMessage;
+
+  /// Print [error.response.data] if true
+  final bool printErrorData;
+
+  /// Print [error.response.headers] if true
+  final bool printErrorHeaders;
+
+  /// Print [error.message] if true
+  final bool printErrorMessage;
 
   /// Print [request.data] if true
   final bool printRequestData;
@@ -72,10 +85,17 @@ class TalkerDioLoggerSettings {
   /// You can add your custom logic to log only specific HTTP responses [Response].
   final bool Function(Response response)? responseFilter;
 
+  /// For error filtering.
+  /// You can add your custom logic to log only specific Dio error [DioException].
+  final bool Function(DioException response)? errorFilter;
+
   TalkerDioLoggerSettings copyWith({
     bool? printResponseData,
     bool? printResponseHeaders,
     bool? printResponseMessage,
+    bool? printErrorData,
+    bool? printErrorHeaders,
+    bool? printErrorMessage,
     bool? printRequestData,
     bool? printRequestHeaders,
     AnsiPen? requestPen,
@@ -83,11 +103,15 @@ class TalkerDioLoggerSettings {
     AnsiPen? errorPen,
     bool Function(RequestOptions requestOptions)? requestFilter,
     bool Function(Response response)? responseFilter,
+    bool Function(DioException response)? errorFilter,
   }) {
     return TalkerDioLoggerSettings(
       printResponseData: printResponseData ?? this.printResponseData,
       printResponseHeaders: printResponseHeaders ?? this.printResponseHeaders,
       printResponseMessage: printResponseMessage ?? this.printResponseMessage,
+      printErrorData: printErrorData ?? this.printErrorData,
+      printErrorHeaders: printErrorHeaders ?? this.printErrorHeaders,
+      printErrorMessage: printErrorMessage ?? this.printErrorMessage,
       printRequestData: printRequestData ?? this.printRequestData,
       printRequestHeaders: printRequestHeaders ?? this.printRequestHeaders,
       requestPen: requestPen ?? this.requestPen,
@@ -95,6 +119,7 @@ class TalkerDioLoggerSettings {
       errorPen: errorPen ?? this.errorPen,
       requestFilter: requestFilter ?? this.requestFilter,
       responseFilter: responseFilter ?? this.responseFilter,
+      errorFilter: errorFilter ?? this.errorFilter,
     );
   }
 }

--- a/packages/talker_dio_logger/test/logs_test.dart
+++ b/packages/talker_dio_logger/test/logs_test.dart
@@ -151,6 +151,42 @@ void main() {
     });
 
     test(
+        'generateTextMessage should not include data, header and message if disabled',
+        () {
+      final dioException = DioException(
+          requestOptions: RequestOptions(path: '/test', method: 'GET'),
+          message: 'Error message',
+          response: Response(
+              requestOptions: RequestOptions(path: '/test', method: 'GET'),
+              headers: Headers.fromMap(
+                {
+                  'content-type': ['application/json'],
+                },
+              )));
+      final settings = TalkerDioLoggerSettings(
+        errorPen: AnsiPen()..blue(),
+        printErrorData: false,
+        printErrorHeaders: false,
+        printErrorMessage: false,
+      );
+      final dioErrorLog = DioErrorLog('Error title',
+          dioException: dioException, settings: settings);
+
+      final result = dioErrorLog.generateTextMessage();
+      expect(result, contains('[log] [GET] Error title'));
+      expect(result, isNot(contains('Message: Error message')));
+      expect(
+          result,
+          isNot(contains(
+            'Headers: {\n'
+            '  "content-type": [\n'
+            '    "application/json"\n'
+            '  ]\n'
+            '}',
+          )));
+    });
+
+    test(
         'generateTextMessage should include status if response has a status code',
         () {
       final response = Response(

--- a/packages/talker_dio_logger/test/settings_test.dart
+++ b/packages/talker_dio_logger/test/settings_test.dart
@@ -10,12 +10,14 @@ void main() {
       final updatedSettings = originalSettings.copyWith(
         printResponseData: false,
         printRequestHeaders: true,
+        printErrorHeaders: false,
         requestPen: AnsiPen()..yellow(),
         responseFilter: null,
       );
 
       expect(updatedSettings.printResponseData, equals(false));
       expect(updatedSettings.printRequestHeaders, equals(true));
+      expect(updatedSettings.printErrorHeaders, equals(false));
       expect(
           updatedSettings.requestPen, isNot(same(originalSettings.requestPen)));
       expect(updatedSettings.responseFilter, isNull);
@@ -46,6 +48,21 @@ void main() {
       expect(settings.responseFilter!(unsuccessfulResponse), equals(false));
     });
 
+    test('errorFilter should return true for cancelled responses', () {
+      final settings = TalkerDioLoggerSettings(
+          errorFilter: (DioException err) =>
+              err.type == DioExceptionType.cancel);
+      final cancelledResponse = DioException(
+          requestOptions: RequestOptions(path: '/test'),
+          type: DioExceptionType.cancel);
+      final timeoutResponse = DioException(
+          requestOptions: RequestOptions(path: '/test'),
+          type: DioExceptionType.sendTimeout);
+
+      expect(settings.errorFilter!(cancelledResponse), equals(true));
+      expect(settings.errorFilter!(timeoutResponse), equals(false));
+    });
+
     test(
         'copyWith should create a new instance with updated values for all fields',
         () {
@@ -55,6 +72,8 @@ void main() {
         printResponseMessage: true,
         printRequestData: true,
         printRequestHeaders: false,
+        printErrorHeaders: false,
+        printErrorData: true,
         requestPen: AnsiPen()..green(),
         responsePen: AnsiPen()..cyan(),
         errorPen: AnsiPen()..red(),
@@ -63,6 +82,8 @@ void main() {
       final updatedSettings = originalSettings.copyWith(
         printResponseData: false,
         printRequestHeaders: true,
+        printErrorHeaders: true,
+        printErrorData: false,
         requestPen: AnsiPen()..yellow(),
       );
 
@@ -70,6 +91,8 @@ void main() {
       expect(updatedSettings.printResponseHeaders, equals(false));
       expect(updatedSettings.printResponseMessage, equals(true));
       expect(updatedSettings.printRequestData, equals(true));
+      expect(updatedSettings.printErrorHeaders, equals(true));
+      expect(updatedSettings.printErrorData, equals(false));
       expect(
         updatedSettings.printRequestHeaders,
         equals(true),


### PR DESCRIPTION
### Thanks a lot for contributing!<br>
Currently, there are settings available to control logging for request and response fields, but not for error logging. This PR addresses this by introducing error settings for the Dio logger:

- `printErrorData`
- `printErrorHeaders`
- `printErrorMessage`
- `errorFilter`
   