### PR TITLE
feat(talker_riverpod_logger): Include the name of the Provider in the output

### DIFF
--- a/packages/talker_riverpod_logger/example/lib/talker_bloc_logger_example.dart
+++ b/packages/talker_riverpod_logger/example/lib/talker_bloc_logger_example.dart
@@ -21,14 +21,17 @@ import 'models.dart';
 /// Creates a [Repository].
 ///
 /// This will correctly wait until the configurations are available.
-final repositoryProvider = FutureProvider<Repository>((ref) async {
-  final repository = Repository();
-  // Releases the resources when the provider is destroyed.
-  // This will stop pending HTTP requests.
-  ref.onDispose(repository.dispose);
+final repositoryProvider = FutureProvider<Repository>(
+  (ref) async {
+    final repository = Repository();
+    // Releases the resources when the provider is destroyed.
+    // This will stop pending HTTP requests.
+    ref.onDispose(repository.dispose);
 
-  return repository;
-});
+    return repository;
+  },
+  name: 'repositoryProvider',
+);
 
 Future<void> main() async {
   // Where the state of our providers will be stored.

--- a/packages/talker_riverpod_logger/lib/riverpod_logs.dart
+++ b/packages/talker_riverpod_logger/lib/riverpod_logs.dart
@@ -2,13 +2,29 @@ import 'package:riverpod/riverpod.dart';
 import 'package:talker/talker.dart';
 import 'package:talker_riverpod_logger/talker_riverpod_logger.dart';
 
+String _defaultMessage({
+  required ProviderBase<Object?> provider,
+  required String suffix,
+}) {
+  if (provider.name == null) {
+    return '${provider.runtimeType} $suffix';
+  }
+
+  return '${provider.name} | ${provider.runtimeType} $suffix';
+}
+
 /// [Riverpod] add provider log model
 class RiverpodAddLog extends TalkerLog {
   RiverpodAddLog({
     required this.provider,
     required this.value,
     required this.settings,
-  }) : super('${provider.runtimeType} initialized');
+  }) : super(
+          _defaultMessage(
+            provider: provider,
+            suffix: 'initialized',
+          ),
+        );
 
   final ProviderBase<Object?> provider;
   final Object? value;
@@ -39,7 +55,12 @@ class RiverpodUpdateLog extends TalkerLog {
     required this.previousValue,
     required this.newValue,
     required this.settings,
-  }) : super('${provider.runtimeType} updated');
+  }) : super(
+          _defaultMessage(
+            provider: provider,
+            suffix: 'updated',
+          ),
+        );
 
   final ProviderBase<Object?> provider;
   final Object? previousValue;
@@ -71,7 +92,12 @@ class RiverpodDisposeLog extends TalkerLog {
   RiverpodDisposeLog({
     required this.provider,
     required this.settings,
-  }) : super('${provider.runtimeType} disposed');
+  }) : super(
+          _defaultMessage(
+            provider: provider,
+            suffix: 'disposed',
+          ),
+        );
 
   final ProviderBase<Object?> provider;
   final TalkerRiverpodLoggerSettings settings;
@@ -99,7 +125,12 @@ class RiverpodFailLog extends TalkerLog {
     required this.providerError,
     required this.providerStackTrace,
     required this.settings,
-  }) : super('${provider.runtimeType} failed');
+  }) : super(
+          _defaultMessage(
+            provider: provider,
+            suffix: 'failed',
+          ),
+        );
 
   final ProviderBase<Object?> provider;
   final Object providerError;

--- a/packages/talker_riverpod_logger/test/logs_test.dart
+++ b/packages/talker_riverpod_logger/test/logs_test.dart
@@ -28,6 +28,34 @@ void main() {
     });
   });
 
+  group('RiverpodAddLog with name', () {
+    test('Constructor should set values correctly', () {
+      final fakeProvider = StateProvider(
+        (ref) => 0,
+        name: 'fakeProvider',
+      );
+      final fakeValue = Object();
+      final fakeSettings = TalkerRiverpodLoggerSettings();
+
+      final log = RiverpodAddLog(
+        provider: fakeProvider,
+        value: fakeValue,
+        settings: fakeSettings,
+      );
+
+      expect(log.provider, fakeProvider);
+      expect(log.value, fakeValue);
+      expect(log.settings, fakeSettings);
+      expect(log.key, TalkerLogType.riverpodAdd.key);
+
+      final message = log.generateTextMessage();
+      expect(message, isA<String>());
+      expect(message, isNotEmpty);
+      expect(message, contains('initialized'));
+      expect(message, contains('fakeProvider'));
+    });
+  });
+
   group('RiverpodUpdateLog', () {
     test('Constructor should set values correctly', () {
       final fakeProvider = StateProvider((ref) => 0);
@@ -55,6 +83,37 @@ void main() {
     });
   });
 
+  group('RiverpodUpdateLog with name', () {
+    test('Constructor should set values correctly', () {
+      final fakeProvider = StateProvider(
+        (ref) => 0,
+        name: 'fakeProvider',
+      );
+      final fakePreviousValue = Object();
+      final fakeNewValue = Object();
+      final fakeSettings = TalkerRiverpodLoggerSettings();
+
+      final log = RiverpodUpdateLog(
+        provider: fakeProvider,
+        previousValue: fakePreviousValue,
+        newValue: fakeNewValue,
+        settings: fakeSettings,
+      );
+
+      expect(log.provider, fakeProvider);
+      expect(log.previousValue, fakePreviousValue);
+      expect(log.newValue, fakeNewValue);
+      expect(log.settings, fakeSettings);
+      expect(log.key, TalkerLogType.riverpodUpdate.key);
+
+      final message = log.generateTextMessage();
+      expect(message, isA<String>());
+      expect(message, isNotEmpty);
+      expect(message, contains('updated'));
+      expect(message, contains('fakeProvider'));
+    });
+  });
+
   group('RiverpodDisposeLog', () {
     test('Constructor should set values correctly', () {
       final fakeProvider = StateProvider((ref) => 0);
@@ -73,6 +132,31 @@ void main() {
       expect(message, isA<String>());
       expect(message, isNotEmpty);
       expect(message, contains('disposed'));
+    });
+  });
+
+  group('RiverpodDisposeLog with name', () {
+    test('Constructor should set values correctly', () {
+      final fakeProvider = StateProvider(
+        (ref) => 0,
+        name: 'fakeProvider',
+      );
+      final fakeSettings = TalkerRiverpodLoggerSettings();
+
+      final log = RiverpodDisposeLog(
+        provider: fakeProvider,
+        settings: fakeSettings,
+      );
+
+      expect(log.provider, fakeProvider);
+      expect(log.settings, fakeSettings);
+      expect(log.key, TalkerLogType.riverpodDispose.key);
+
+      final message = log.generateTextMessage();
+      expect(message, isA<String>());
+      expect(message, isNotEmpty);
+      expect(message, contains('disposed'));
+      expect(message, contains('fakeProvider'));
     });
   });
 
@@ -99,6 +183,36 @@ void main() {
       expect(message, isA<String>());
       expect(message, isNotEmpty);
       expect(message, contains('failed'));
+    });
+  });
+
+  group('RiverpodFailLog with name', () {
+    test('Constructor should set values correctly', () {
+      final fakeProvider = StateProvider(
+        (ref) => 0,
+        name: 'fakeProvider',
+      );
+      final fakeError = Object();
+      final fakeStackTrace = StackTrace.empty;
+      final fakeSettings = TalkerRiverpodLoggerSettings();
+
+      final log = RiverpodFailLog(
+        provider: fakeProvider,
+        providerError: fakeError,
+        providerStackTrace: fakeStackTrace,
+        settings: fakeSettings,
+      );
+
+      expect(log.provider, fakeProvider);
+      expect(log.providerError, fakeError);
+      expect(log.providerStackTrace, fakeStackTrace);
+      expect(log.key, TalkerLogType.riverpodFail.key);
+
+      final message = log.generateTextMessage();
+      expect(message, isA<String>());
+      expect(message, isNotEmpty);
+      expect(message, contains('failed'));
+      expect(message, contains('fakeProvider'));
     });
   });
 }


### PR DESCRIPTION
fixed #233

with out name
```console
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ [riverpod-add] | 10:46:24 611ms | 
│ FutureProvider<Repository> initialized
│ INITIAL state: 
│ AsyncLoading<Repository>()
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ [riverpod-update] | 10:46:24 618ms | 
│ FutureProvider<Repository> updated
│ PREVIOUS state: 
│ AsyncLoading<Repository>()
│ NEW state: 
│ AsyncData<Repository>(value: Instance of 'Repository')
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

with name
```console
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ [riverpod-add] | 10:36:20 129ms | 
│ repositoryProvider | FutureProvider<Repository> initialized
│ INITIAL state: 
│ AsyncLoading<Repository>()
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ [riverpod-update] | 10:36:20 136ms | 
│ repositoryProvider | FutureProvider<Repository> updated
│ PREVIOUS state: 
│ AsyncLoading<Repository>()
│ NEW state: 
│ AsyncData<Repository>(value: Instance of 'Repository')
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────
```
