### PR TITLE
Talker Riverpod update: print full data for talker page

### DIFF
--- a/packages/talker_dio_logger/example/pubspec.lock
+++ b/packages/talker_dio_logger/example/pubspec.lock
@@ -345,7 +345,7 @@ packages:
     dependency: transitive
     description:
       name: talker
-      sha256: a36980246ff1f8885d1e008e6a9af82726db56432ff80b0ee9cd160e03767f34
+      sha256: f876081a34027464e3f1ac785c7e470a5fca2515f4c8c277fb6f78a63e5cda1e
       url: "https://pub.dev"
     source: hosted
     version: "4.2.3"
@@ -367,7 +367,7 @@ packages:
     dependency: transitive
     description:
       name: talker_logger
-      sha256: "5d062cd27e57f8d19801e63a8906228e264317bad7bb88f823699b2611b5ce4f"
+      sha256: "8728b67e97a2cd484ed217ec9dca1e05063aa6c9464a1c095e77540f944b1c8a"
       url: "https://pub.dev"
     source: hosted
     version: "4.2.3"

--- a/packages/talker_flutter/.flutter-plugins
+++ b/packages/talker_flutter/.flutter-plugins
@@ -1,10 +1,10 @@
 # This is a generated file; do not edit or check into version control.
-path_provider=/Users/stanislavilin/.pub-cache/hosted/pub.dev/path_provider-2.1.2/
-path_provider_android=/Users/stanislavilin/.pub-cache/hosted/pub.dev/path_provider_android-2.2.0/
-path_provider_foundation=/Users/stanislavilin/.pub-cache/hosted/pub.dev/path_provider_foundation-2.3.1/
-path_provider_linux=/Users/stanislavilin/.pub-cache/hosted/pub.dev/path_provider_linux-2.2.1/
-path_provider_windows=/Users/stanislavilin/.pub-cache/hosted/pub.dev/path_provider_windows-2.2.1/
-share_plus=/Users/stanislavilin/.pub-cache/hosted/pub.dev/share_plus-9.0.0/
-url_launcher_linux=/Users/stanislavilin/.pub-cache/hosted/pub.dev/url_launcher_linux-3.0.5/
-url_launcher_web=/Users/stanislavilin/.pub-cache/hosted/pub.dev/url_launcher_web-2.0.16/
-url_launcher_windows=/Users/stanislavilin/.pub-cache/hosted/pub.dev/url_launcher_windows-3.0.6/
+path_provider=/Users/yelamanyelmuratov/.pub-cache/hosted/pub.dev/path_provider-2.1.3/
+path_provider_android=/Users/yelamanyelmuratov/.pub-cache/hosted/pub.dev/path_provider_android-2.2.4/
+path_provider_foundation=/Users/yelamanyelmuratov/.pub-cache/hosted/pub.dev/path_provider_foundation-2.4.0/
+path_provider_linux=/Users/yelamanyelmuratov/.pub-cache/hosted/pub.dev/path_provider_linux-2.2.1/
+path_provider_windows=/Users/yelamanyelmuratov/.pub-cache/hosted/pub.dev/path_provider_windows-2.2.1/
+share_plus=/Users/yelamanyelmuratov/.pub-cache/hosted/pub.dev/share_plus-9.0.0/
+url_launcher_linux=/Users/yelamanyelmuratov/.pub-cache/hosted/pub.dev/url_launcher_linux-3.1.1/
+url_launcher_web=/Users/yelamanyelmuratov/.pub-cache/hosted/pub.dev/url_launcher_web-2.3.1/
+url_launcher_windows=/Users/yelamanyelmuratov/.pub-cache/hosted/pub.dev/url_launcher_windows-3.1.1/

--- a/packages/talker_flutter/example/pubspec.lock
+++ b/packages/talker_flutter/example/pubspec.lock
@@ -337,7 +337,7 @@ packages:
     dependency: transitive
     description:
       name: talker
-      sha256: a36980246ff1f8885d1e008e6a9af82726db56432ff80b0ee9cd160e03767f34
+      sha256: f876081a34027464e3f1ac785c7e470a5fca2515f4c8c277fb6f78a63e5cda1e
       url: "https://pub.dev"
     source: hosted
     version: "4.2.3"
@@ -352,7 +352,7 @@ packages:
     dependency: transitive
     description:
       name: talker_logger
-      sha256: "5d062cd27e57f8d19801e63a8906228e264317bad7bb88f823699b2611b5ce4f"
+      sha256: "8728b67e97a2cd484ed217ec9dca1e05063aa6c9464a1c095e77540f944b1c8a"
       url: "https://pub.dev"
     source: hosted
     version: "4.2.3"

--- a/packages/talker_riverpod_logger/lib/riverpod_logs.dart
+++ b/packages/talker_riverpod_logger/lib/riverpod_logs.dart
@@ -21,9 +21,10 @@ class RiverpodAddLog extends TalkerLog {
     required this.settings,
   }) : super(
           _defaultMessage(
-            provider: provider,
-            suffix: 'initialized',
-          ),
+                provider: provider,
+                suffix: 'initialized',
+              ) +
+              (settings.printStateFullData ? '\nINITIAL state: \n$value' : ''),
         );
 
   final ProviderBase<Object?> provider;
@@ -42,8 +43,7 @@ class RiverpodAddLog extends TalkerLog {
     final sb = StringBuffer();
     sb.write(displayTitleWithTime);
     sb.write('\n$message');
-    sb.write(
-        '\n${'INITIAL state: ${settings.printStateFullData ? '\n$value' : value.runtimeType}'}');
+    sb.write('\n${'INITIAL state: ${settings.printStateFullData ? '\n$value' : value.runtimeType}'}');
     return sb.toString();
   }
 }
@@ -57,9 +57,10 @@ class RiverpodUpdateLog extends TalkerLog {
     required this.settings,
   }) : super(
           _defaultMessage(
-            provider: provider,
-            suffix: 'updated',
-          ),
+                provider: provider,
+                suffix: 'updated',
+              ) +
+              (settings.printStateFullData ? '\nPREVIOUS state:\n$previousValue\nNEW state:\n$newValue' : ''),
         );
 
   final ProviderBase<Object?> provider;
@@ -79,10 +80,8 @@ class RiverpodUpdateLog extends TalkerLog {
     final sb = StringBuffer();
     sb.write(displayTitleWithTime);
     sb.write('\n$message');
-    sb.write(
-        '\n${'PREVIOUS state: ${settings.printStateFullData ? '\n$previousValue' : previousValue.runtimeType}'}');
-    sb.write(
-        '\n${'NEW state: ${settings.printStateFullData ? '\n$newValue' : newValue.runtimeType}'}');
+    sb.write('\n${'PREVIOUS state: ${settings.printStateFullData ? '\n$previousValue' : previousValue.runtimeType}'}');
+    sb.write('\n${'NEW state: ${settings.printStateFullData ? '\n$newValue' : newValue.runtimeType}'}');
     return sb.toString();
   }
 }
@@ -127,9 +126,10 @@ class RiverpodFailLog extends TalkerLog {
     required this.settings,
   }) : super(
           _defaultMessage(
-            provider: provider,
-            suffix: 'failed',
-          ),
+                provider: provider,
+                suffix: 'failed',
+              ) +
+              (settings.printFailFullData ? '\nERROR:\n$providerError\nSTACK TRACE:\n$providerStackTrace' : ''),
         );
 
   final ProviderBase<Object?> provider;

--- a/packages/talker_riverpod_logger/lib/riverpod_logs.dart
+++ b/packages/talker_riverpod_logger/lib/riverpod_logs.dart
@@ -43,7 +43,8 @@ class RiverpodAddLog extends TalkerLog {
     final sb = StringBuffer();
     sb.write(displayTitleWithTime);
     sb.write('\n$message');
-    sb.write('\n${'INITIAL state: ${settings.printStateFullData ? '\n$value' : value.runtimeType}'}');
+    sb.write(
+        '\n${'INITIAL state: ${settings.printStateFullData ? '\n$value' : value.runtimeType}'}');
     return sb.toString();
   }
 }
@@ -60,7 +61,9 @@ class RiverpodUpdateLog extends TalkerLog {
                 provider: provider,
                 suffix: 'updated',
               ) +
-              (settings.printStateFullData ? '\nPREVIOUS state:\n$previousValue\nNEW state:\n$newValue' : ''),
+              (settings.printStateFullData
+                  ? '\nPREVIOUS state:\n$previousValue\nNEW state:\n$newValue'
+                  : ''),
         );
 
   final ProviderBase<Object?> provider;
@@ -80,8 +83,10 @@ class RiverpodUpdateLog extends TalkerLog {
     final sb = StringBuffer();
     sb.write(displayTitleWithTime);
     sb.write('\n$message');
-    sb.write('\n${'PREVIOUS state: ${settings.printStateFullData ? '\n$previousValue' : previousValue.runtimeType}'}');
-    sb.write('\n${'NEW state: ${settings.printStateFullData ? '\n$newValue' : newValue.runtimeType}'}');
+    sb.write(
+        '\n${'PREVIOUS state: ${settings.printStateFullData ? '\n$previousValue' : previousValue.runtimeType}'}');
+    sb.write(
+        '\n${'NEW state: ${settings.printStateFullData ? '\n$newValue' : newValue.runtimeType}'}');
     return sb.toString();
   }
 }
@@ -129,7 +134,9 @@ class RiverpodFailLog extends TalkerLog {
                 provider: provider,
                 suffix: 'failed',
               ) +
-              (settings.printFailFullData ? '\nERROR:\n$providerError\nSTACK TRACE:\n$providerStackTrace' : ''),
+              (settings.printFailFullData
+                  ? '\nERROR:\n$providerError\nSTACK TRACE:\n$providerStackTrace'
+                  : ''),
         );
 
   final ProviderBase<Object?> provider;

--- a/packages/talker_riverpod_logger/lib/talker_riverpod_logger_settings.dart
+++ b/packages/talker_riverpod_logger/lib/talker_riverpod_logger_settings.dart
@@ -8,6 +8,7 @@ class TalkerRiverpodLoggerSettings {
     this.printProviderDisposed = false,
     this.printProviderFailed = true,
     this.printStateFullData = true,
+    this.printFailFullData = true,
     this.providerFilter,
   });
 
@@ -17,5 +18,6 @@ class TalkerRiverpodLoggerSettings {
   final bool printProviderDisposed;
   final bool printProviderFailed;
   final bool printStateFullData;
+  final bool printFailFullData;
   final bool Function(ProviderBase<Object?> provider)? providerFilter;
 }


### PR DESCRIPTION
Right now Riverpod Talker only displays full information for the console, but there is literally no information in the Talker Page itself. Not about the stats, not about the errors, stack trace.
I've changed the code to add more information, also added a new field for errors printFailFullData.