### PR TITLE
Fix showing times on FlutterScreen cards

### DIFF
--- a/packages/talker_flutter/lib/src/ui/widgets/data_card.dart
+++ b/packages/talker_flutter/lib/src/ui/widgets/data_card.dart
@@ -72,7 +72,7 @@ class _TalkerDataCardState extends State<TalkerDataCard> {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         Text(
-                          '${widget.data.title} | ${widget.data.displayTime}',
+                          '${widget.data.title} | ${widget.data.displayTime()}',
                           style: TextStyle(
                             color: widget.color,
                             fontWeight: FontWeight.w700,


### PR DESCRIPTION
This PR fixes the TalkerDataCard titles to show a time instead of `{Closure: TimeFormat timeFormat}` on FlutterScreen widgets.