### PR TITLE
Fix some bloc logs

### DIFF
--- a/packages/talker_bloc_logger/lib/bloc_logs.dart
+++ b/packages/talker_bloc_logger/lib/bloc_logs.dart
@@ -92,7 +92,7 @@ class BlocChangeLog extends TalkerLog {
 
   String _createMessage() {
     final sb = StringBuffer();
-    sb.write(displayTitleWithTime);
+    sb.write(displayTitleWithTime());
     sb.write('\n$message');
     sb.write(
         '\n${'CURRENT state: ${settings.printStateFullData ? '\n${change.currentState}' : change.currentState.runtimeType}'}');
@@ -122,7 +122,7 @@ class BlocCreateLog extends TalkerLog {
 
   String _createMessage() {
     final sb = StringBuffer();
-    sb.write(displayTitleWithTime);
+    sb.write(displayTitleWithTime());
     sb.write('\n$message');
     return sb.toString();
   }
@@ -148,7 +148,7 @@ class BlocCloseLog extends TalkerLog {
 
   String _createMessage() {
     final sb = StringBuffer();
-    sb.write(displayTitleWithTime);
+    sb.write(displayTitleWithTime());
     sb.write('\n$message');
     return sb.toString();
   }


### PR DESCRIPTION
Hi, thanks a lot for this logger, really cool.
However, I noticed that with some bloc events are logged in the console with the date not formatted; it instead prints:
```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ Closure: ({TimeFormat timeFormat}) => String from: opts => {
│       let timeFormat = opts && 'timeFormat' in opts ? opts.timeFormat : C[23] || CT.C23;
│       return talker_data['FieldsToDisplay|displayTitleWithTime']($this, {timeFormat: timeFormat});
│     }
│ LoginBloc created
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────
```

With my fix the logs are printed correctly, outputing
```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────
│ [bloc-create] | 12:41:39 387ms |
│ LoginBloc created
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────
```