### PR TITLE
Show full data of Bloc logs in Flutter Talker

### DIFF
--- a/packages/talker_bloc_logger/lib/bloc_logs.dart
+++ b/packages/talker_bloc_logger/lib/bloc_logs.dart
@@ -72,8 +72,8 @@ class BlocChangeLog extends TalkerLog {
     required this.change,
     required this.settings,
   }) : super('${bloc.runtimeType} changed'
-            '\n${'CURRENT state: ${settings.printStateFullData ? '\n${change.currentState}' : change.currentState.runtimeType}'}'
-            '\n${'NEXT state: ${settings.printStateFullData ? '\n${change.nextState}' : change.nextState.runtimeType}'}');
+            '\nCURRENT state: ${_formatStateDetails(state: change.currentState, printFullData: settings.printStateFullData)}'
+            '\nNEXT state: ${_formatStateDetails(state: change.nextState, printFullData: settings.printStateFullData)}');
 
   final BlocBase bloc;
   final Change change;

--- a/packages/talker_bloc_logger/lib/bloc_logs.dart
+++ b/packages/talker_bloc_logger/lib/bloc_logs.dart
@@ -40,13 +40,6 @@ class BlocStateLog extends TalkerLog {
             '\nCURRENT state: ${_formatCurrentState(transition.currentState, settings)}'
             '\nNEXT state: ${_formatNextState(transition.nextState, settings)}');
 
-  String _formatCurrentState(Object? currentState, TalkerBlocLoggerSettings settings) {
-    return settings.printStateFullData ? '\n$currentState' : currentState.runtimeType.toString();
-  }
-
-  String _formatNextState(Object? nextState, TalkerBlocLoggerSettings settings) {
-    return settings.printStateFullData ? '\n$nextState' : nextState.runtimeType.toString();
-  }
   final Bloc bloc;
   final Transition transition;
   final TalkerBlocLoggerSettings settings;
@@ -72,8 +65,8 @@ class BlocChangeLog extends TalkerLog {
     required this.change,
     required this.settings,
   }) : super('${bloc.runtimeType} changed'
-            '\nCURRENT state: ${_formatStateDetails(state: change.currentState, printFullData: settings.printStateFullData)}'
-            '\nNEXT state: ${_formatStateDetails(state: change.nextState, printFullData: settings.printStateFullData)}');
+            '\nCURRENT state: ${_formatCurrentState(change.currentState, settings)}'
+            '\nNEXT state: ${_formatNextState(change.nextState, settings)}');
 
   final BlocBase bloc;
   final Change change;
@@ -91,6 +84,24 @@ class BlocChangeLog extends TalkerLog {
     sb.write('\n$message');
     return sb.toString();
   }
+}
+
+String _formatCurrentState(
+  Object? currentState,
+  TalkerBlocLoggerSettings settings,
+) {
+  return settings.printStateFullData
+      ? '\n$currentState'
+      : currentState.runtimeType.toString();
+}
+
+String _formatNextState(
+  Object? nextState,
+  TalkerBlocLoggerSettings settings,
+) {
+  return settings.printStateFullData
+      ? '\n$nextState'
+      : nextState.runtimeType.toString();
 }
 
 /// [Bloc] created log model

--- a/packages/talker_bloc_logger/lib/bloc_logs.dart
+++ b/packages/talker_bloc_logger/lib/bloc_logs.dart
@@ -37,9 +37,16 @@ class BlocStateLog extends TalkerLog {
     required this.transition,
     required this.settings,
   }) : super('${bloc.runtimeType} with event ${transition.event.runtimeType}'
-            '\n${'CURRENT state: ${settings.printStateFullData ? '\n${transition.currentState}' : transition.currentState.runtimeType}'}'
-            '\n${'NEXT state: ${settings.printStateFullData ? '\n${transition.nextState}' : transition.nextState.runtimeType}'}');
+            '\nCURRENT state: ${_formatCurrentState(transition.currentState, settings)}'
+            '\nNEXT state: ${_formatNextState(transition.nextState, settings)}');
 
+  String _formatCurrentState(Object? currentState, TalkerBlocLoggerSettings settings) {
+    return settings.printStateFullData ? '\n$currentState' : currentState.runtimeType.toString();
+  }
+
+  String _formatNextState(Object? nextState, TalkerBlocLoggerSettings settings) {
+    return settings.printStateFullData ? '\n$nextState' : nextState.runtimeType.toString();
+  }
   final Bloc bloc;
   final Transition transition;
   final TalkerBlocLoggerSettings settings;

--- a/packages/talker_bloc_logger/lib/bloc_logs.dart
+++ b/packages/talker_bloc_logger/lib/bloc_logs.dart
@@ -36,7 +36,9 @@ class BlocStateLog extends TalkerLog {
     required this.bloc,
     required this.transition,
     required this.settings,
-  }) : super('${bloc.runtimeType} with event ${transition.event.runtimeType}');
+  }) : super('${bloc.runtimeType} with event ${transition.event.runtimeType}'
+            '\n${'CURRENT state: ${settings.printStateFullData ? '\n${transition.currentState}' : transition.currentState.runtimeType}'}'
+            '\n${'NEXT state: ${settings.printStateFullData ? '\n${transition.nextState}' : transition.nextState.runtimeType}'}');
 
   final Bloc bloc;
   final Transition transition;
@@ -52,10 +54,6 @@ class BlocStateLog extends TalkerLog {
     final sb = StringBuffer();
     sb.write(displayTitleWithTime(timeFormat: timeFormat));
     sb.write('\n$message');
-    sb.write(
-        '\n${'CURRENT state: ${settings.printStateFullData ? '\n${transition.currentState}' : transition.currentState.runtimeType}'}');
-    sb.write(
-        '\n${'NEXT state: ${settings.printStateFullData ? '\n${transition.nextState}' : transition.nextState.runtimeType}'}');
     return sb.toString();
   }
 }
@@ -66,7 +64,9 @@ class BlocChangeLog extends TalkerLog {
     required this.bloc,
     required this.change,
     required this.settings,
-  }) : super('${bloc.runtimeType} changed');
+  }) : super('${bloc.runtimeType} changed'
+            '\n${'CURRENT state: ${settings.printStateFullData ? '\n${change.currentState}' : change.currentState.runtimeType}'}'
+            '\n${'NEXT state: ${settings.printStateFullData ? '\n${change.nextState}' : change.nextState.runtimeType}'}');
 
   final BlocBase bloc;
   final Change change;
@@ -82,10 +82,6 @@ class BlocChangeLog extends TalkerLog {
     final sb = StringBuffer();
     sb.write(displayTitleWithTime(timeFormat: timeFormat));
     sb.write('\n$message');
-    sb.write(
-        '\n${'CURRENT state: ${settings.printStateFullData ? '\n${change.currentState}' : change.currentState.runtimeType}'}');
-    sb.write(
-        '\n${'NEXT state: ${settings.printStateFullData ? '\n${change.nextState}' : change.nextState.runtimeType}'}');
     return sb.toString();
   }
 }


### PR DESCRIPTION
Hello!
This pull request fixes a minor bug in the Flutter Talker Screen; basically since the `BlocStateLog` and the `BlocChangeLog` didn't call `super()` with all the data they provide, only part of the information was getting into the message field of the `TalkerLog`, resulting in only part of data being shown in the actual application, while the full data was printed in debug console.

Before:
<img width="1029" alt="image" src="https://github.com/user-attachments/assets/52e4b22f-2d74-43a5-8553-4dc340556916">

After:
<img width="1026" alt="image" src="https://github.com/user-attachments/assets/0090d2a7-ecc2-42a4-9167-38d6e99565db">

