### PR TITLE
fix: TalkerLog pen color

### DIFF
--- a/packages/talker/lib/src/talker.dart
+++ b/packages/talker/lib/src/talker.dart
@@ -367,7 +367,7 @@ class Talker {
       title: settings.getTitleByLogType(type),
       exception: exception,
       stackTrace: stackTrace,
-      pen: settings.getAnsiPenByLogType(type),
+      pen: pen ?? settings.getAnsiPenByLogType(type),
       logLevel: logLevel,
     );
     _handleLogData(data);


### PR DESCRIPTION
Passed parameter `pen` color inside TalkerLog in `_handleLog` method is ignored, even if set.

