### PR TITLE
feat(talker_dio_logger): add enable option to control log output

### DIFF
--- a/packages/talker_dio_logger/lib/talker_dio_logger_interceptor.dart
+++ b/packages/talker_dio_logger/lib/talker_dio_logger_interceptor.dart
@@ -61,6 +61,9 @@ class TalkerDioLogger extends Interceptor {
     RequestInterceptorHandler handler,
   ) {
     super.onRequest(options, handler);
+    if (!settings.enabled) {
+      return;
+    }
     final accepted = settings.requestFilter?.call(options) ?? true;
     if (!accepted) {
       return;
@@ -81,6 +84,9 @@ class TalkerDioLogger extends Interceptor {
   @override
   void onResponse(Response response, ResponseInterceptorHandler handler) {
     super.onResponse(response, handler);
+    if (!settings.enabled) {
+      return;
+    }
     final accepted = settings.responseFilter?.call(response) ?? true;
     if (!accepted) {
       return;
@@ -101,6 +107,9 @@ class TalkerDioLogger extends Interceptor {
   @override
   void onError(DioException err, ErrorInterceptorHandler handler) {
     super.onError(err, handler);
+    if (!settings.enabled) {
+      return;
+    }
     final accepted = settings.errorFilter?.call(err) ?? true;
     if (!accepted) {
       return;

--- a/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
+++ b/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
@@ -4,6 +4,7 @@ import 'package:talker/talker.dart';
 /// [TalkerDioLogger] settings and customization
 class TalkerDioLoggerSettings {
   const TalkerDioLoggerSettings({
+    this.enabled = true,
     this.printResponseData = true,
     this.printResponseHeaders = false,
     this.printResponseMessage = true,
@@ -19,6 +20,9 @@ class TalkerDioLoggerSettings {
     this.responseFilter,
     this.errorFilter,
   });
+
+  // Print Dio logger if true
+  final bool enabled;
 
   /// Print [response.data] if true
   final bool printResponseData;


### PR DESCRIPTION
### Description
- Added an `enable` option to `talker_dio_logger` to control whether to output logs.
- This functionality mirrors the usage in `talker_riverpod_logger`, allowing selective logging for `Dio` requests.

### Changes
- Added `enable` flag in `talker_dio_logger`
