### PR TITLE
Rename logTyped to logCustom and add deprecated annotation for logTyped

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ class YourCustomLog extends TalkerLog {
 }
 
 final talker = Talker();
-talker.logTyped(YourCustomLog('Something like your own service message'));
+talker.logCustom(YourCustomLog('Something like your own service message'));
 ```
 
 <p align="center"><a href="https://frezyx.github.io/talker" align="center"><img src="https://github.com/Frezyx/talker/blob/dev/docs/assets/logger/custom_log.png?raw=true"></a></p>

--- a/packages/talker/example/talker_example.dart
+++ b/packages/talker/example/talker_example.dart
@@ -30,7 +30,7 @@ Future<void> main() async {
   }
 
   /// Custom logs
-  talker.logTyped(YourCustomLog('Something like your own service message'));
+  talker.logCustom(YourCustomLog('Something like your own service message'));
 }
 
 class YourCustomLog extends TalkerLog {

--- a/packages/talker/lib/src/talker.dart
+++ b/packages/talker/lib/src/talker.dart
@@ -216,6 +216,14 @@ class Talker {
     _handleLog(message, exception, stackTrace, logLevel, pen: pen);
   }
 
+  /// {@macro logCustom}
+  @Deprecated(
+    'Use logCustom instead. '
+    'This feature was deprecated after v4.4.6',
+  )
+  void logTyped(TalkerLog log) => logCustom(log);
+
+  /// {@template logCustom}
   /// Log a new message
   /// created in the full [TalkerLog] model or they subclass
   /// (you can create it by extends of [TalkerLog])
@@ -238,9 +246,8 @@ class Talker {
   ///   final httpLog = HttpTalkerLog('Http status: 200');
   ///   talker.logTyped(httpLog);
   /// ```
-  void logTyped(TalkerLog log) {
-    _handleLogData(log);
-  }
+  /// {@endtemplate}
+  void logCustom(TalkerLog log) => _handleLogData(log);
 
   /// Log a new critical message
   /// [dynamic] [message] - message describes what happened

--- a/packages/talker/lib/src/talker.dart
+++ b/packages/talker/lib/src/talker.dart
@@ -244,7 +244,7 @@ class Talker {
   ///
   ///   //You can add here response model of your request
   ///   final httpLog = HttpTalkerLog('Http status: 200');
-  ///   talker.logTyped(httpLog);
+  ///   talker.logCustom(httpLog);
   /// ```
   /// {@endtemplate}
   void logCustom(TalkerLog log) => _handleLogData(log);

--- a/packages/talker/test/talker_settings_test.dart
+++ b/packages/talker/test/talker_settings_test.dart
@@ -17,7 +17,7 @@ void main() {
         logger: TalkerLogger(),
       );
       final httpLog = HttpTalkerLog('Http good');
-      talker.logTyped(httpLog);
+      talker.logCustom(httpLog);
 
       expect(
         talker.history.whereType<HttpTalkerLog>().isNotEmpty,

--- a/packages/talker/test/talker_test.dart
+++ b/packages/talker/test/talker_test.dart
@@ -1,6 +1,8 @@
 import 'package:talker/talker.dart';
 import 'package:test/test.dart';
 
+import 'talker_settings_test.dart';
+
 class LikeErrorButNot {}
 
 void main() {
@@ -83,5 +85,48 @@ void main() {
       1,
     );
     expect(talker.history.first.message, testLogMessage);
+  });
+
+  test('logCustom', () async {
+    final talker = Talker(
+      logger: TalkerLogger(
+        output: (message) {},
+      ),
+    );
+    final httpLog = HttpTalkerLog('Http good');
+    talker.logCustom(httpLog);
+
+    expect(talker.history.length, 1);
+    expect(
+      talker.history.whereType<TalkerLog>().length,
+      1,
+    );
+    expect(
+      talker.history.whereType<HttpTalkerLog>().length,
+      1,
+    );
+    expect(talker.history.first.message, httpLog.message);
+  });
+
+  test('logTyped', () async {
+    final talker = Talker(
+      logger: TalkerLogger(
+        output: (message) {},
+      ),
+    );
+    final httpLog = HttpTalkerLog('Http good');
+    // ignore: deprecated_member_use_from_same_package
+    talker.logTyped(httpLog);
+
+    expect(talker.history.length, 1);
+    expect(
+      talker.history.whereType<TalkerLog>().length,
+      1,
+    );
+    expect(
+      talker.history.whereType<HttpTalkerLog>().length,
+      1,
+    );
+    expect(talker.history.first.message, httpLog.message);
   });
 }

--- a/packages/talker_bloc_logger/lib/talker_bloc_logger_observer.dart
+++ b/packages/talker_bloc_logger/lib/talker_bloc_logger_observer.dart
@@ -30,7 +30,7 @@ class TalkerBlocObserver extends BlocObserver {
     if (!accepted) {
       return;
     }
-    _talker.logTyped(
+    _talker.logCustom(
       BlocEventLog(
         bloc: bloc,
         event: event,
@@ -50,7 +50,7 @@ class TalkerBlocObserver extends BlocObserver {
     if (!accepted) {
       return;
     }
-    _talker.logTyped(BlocStateLog(
+    _talker.logCustom(BlocStateLog(
       bloc: bloc,
       transition: transition,
       settings: settings,
@@ -63,7 +63,7 @@ class TalkerBlocObserver extends BlocObserver {
     if (!settings.enabled || !settings.printChanges) {
       return;
     }
-    _talker.logTyped(
+    _talker.logCustom(
       BlocChangeLog(
         bloc: bloc,
         change: change,
@@ -85,7 +85,7 @@ class TalkerBlocObserver extends BlocObserver {
     if (!settings.enabled || !settings.printCreations) {
       return;
     }
-    _talker.logTyped(BlocCreateLog(bloc: bloc));
+    _talker.logCustom(BlocCreateLog(bloc: bloc));
   }
 
   @override
@@ -94,6 +94,6 @@ class TalkerBlocObserver extends BlocObserver {
     if (!settings.enabled || !settings.printClosings) {
       return;
     }
-    _talker.logTyped(BlocCloseLog(bloc: bloc));
+    _talker.logCustom(BlocCloseLog(bloc: bloc));
   }
 }

--- a/packages/talker_dio_logger/lib/talker_dio_logger_interceptor.dart
+++ b/packages/talker_dio_logger/lib/talker_dio_logger_interceptor.dart
@@ -75,7 +75,7 @@ class TalkerDioLogger extends Interceptor {
         requestOptions: options,
         settings: settings,
       );
-      _talker.logTyped(httpLog);
+      _talker.logCustom(httpLog);
     } catch (_) {
       //pass
     }
@@ -98,7 +98,7 @@ class TalkerDioLogger extends Interceptor {
         settings: settings,
         response: response,
       );
-      _talker.logTyped(httpLog);
+      _talker.logCustom(httpLog);
     } catch (_) {
       //pass
     }
@@ -121,7 +121,7 @@ class TalkerDioLogger extends Interceptor {
         dioException: err,
         settings: settings,
       );
-      _talker.logTyped(httpErrorLog);
+      _talker.logCustom(httpErrorLog);
     } catch (_) {
       //pass
     }

--- a/packages/talker_flutter/example/lib/extended_example/extended_example.dart
+++ b/packages/talker_flutter/example/lib/extended_example/extended_example.dart
@@ -84,7 +84,8 @@ class _ExtendedExampleState extends State<ExtendedExample> {
   }
 
   void _customLog() {
-    _talker.logCustom(CustomLog('Custom log message'));
+    // ignore: deprecated_member_use_from_same_package
+    _talker.logTyped(CustomLog('Custom log message'));
   }
 
   void _criticalLog() {

--- a/packages/talker_flutter/example/lib/extended_example/extended_example.dart
+++ b/packages/talker_flutter/example/lib/extended_example/extended_example.dart
@@ -84,7 +84,7 @@ class _ExtendedExampleState extends State<ExtendedExample> {
   }
 
   void _customLog() {
-    _talker.logTyped(CustomLog('Custom log message'));
+    _talker.logCustom(CustomLog('Custom log message'));
   }
 
   void _criticalLog() {

--- a/packages/talker_flutter/lib/src/observers/router_observer.dart
+++ b/packages/talker_flutter/lib/src/observers/router_observer.dart
@@ -14,7 +14,7 @@ class TalkerRouteObserver extends NavigatorObserver {
     if (route.settings.name == null) {
       return;
     }
-    talker.logTyped(TalkerRouteLog(route: route));
+    talker.logCustom(TalkerRouteLog(route: route));
   }
 
   @override
@@ -23,7 +23,7 @@ class TalkerRouteObserver extends NavigatorObserver {
     if (route.settings.name == null) {
       return;
     }
-    talker.logTyped(TalkerRouteLog(route: route, isPush: false));
+    talker.logCustom(TalkerRouteLog(route: route, isPush: false));
   }
 }
 

--- a/packages/talker_http_logger/lib/talker_http_logger.dart
+++ b/packages/talker_http_logger/lib/talker_http_logger.dart
@@ -17,7 +17,7 @@ class TalkerHttpLogger extends InterceptorContract {
     required BaseRequest request,
   }) async {
     final message = '${request.url}';
-    _talker.logTyped(HttpRequestLog(message, request: request));
+    _talker.logCustom(HttpRequestLog(message, request: request));
     return request;
   }
 
@@ -26,7 +26,7 @@ class TalkerHttpLogger extends InterceptorContract {
     required BaseResponse response,
   }) async {
     final message = '${response.request?.url}';
-    _talker.logTyped(HttpResponseLog(message, response: response));
+    _talker.logCustom(HttpResponseLog(message, response: response));
     return response;
   }
 }

--- a/packages/talker_riverpod_logger/lib/talker_riverpod_logger_observer.dart
+++ b/packages/talker_riverpod_logger/lib/talker_riverpod_logger_observer.dart
@@ -34,7 +34,7 @@ class TalkerRiverpodObserver extends ProviderObserver {
     if (!accepted) {
       return;
     }
-    _talker.logTyped(
+    _talker.logCustom(
       RiverpodAddLog(
         provider: provider,
         value: value,
@@ -59,7 +59,7 @@ class TalkerRiverpodObserver extends ProviderObserver {
     if (!accepted) {
       return;
     }
-    _talker.logTyped(
+    _talker.logCustom(
       RiverpodUpdateLog(
         provider: provider,
         previousValue: previousValue,
@@ -83,7 +83,7 @@ class TalkerRiverpodObserver extends ProviderObserver {
     if (!accepted) {
       return;
     }
-    _talker.logTyped(
+    _talker.logCustom(
       RiverpodDisposeLog(
         provider: provider,
         settings: settings,
@@ -107,7 +107,7 @@ class TalkerRiverpodObserver extends ProviderObserver {
     if (!accepted) {
       return;
     }
-    _talker.logTyped(
+    _talker.logCustom(
       RiverpodFailLog(
         provider: provider,
         providerError: error,


### PR DESCRIPTION
The name logTyped confuses library users and contributors
The **logTyped()** method will be removed in 5.0.0 version of the package