### PR TITLE
Added isLogsExpanded and isLogOrderReversed flags to TalkerScreen widget

### DIFF
--- a/packages/talker_flutter/example/lib/main.dart
+++ b/packages/talker_flutter/example/lib/main.dart
@@ -71,6 +71,8 @@ class _BaseExampleState extends State<BaseExample> {
         return Scaffold(
           body: TalkerScreen(
             talker: widget.talker,
+            isLogsExpanded: true,
+            isLogOrderReversed: true,
             theme: const TalkerScreenTheme(
               logColors: {
                 YourCustomLog.logKey: Colors.green,

--- a/packages/talker_flutter/lib/src/controller/talker_view_controller.dart
+++ b/packages/talker_flutter/lib/src/controller/talker_view_controller.dart
@@ -7,8 +7,13 @@ import 'package:talker_flutter/talker_flutter.dart';
 class TalkerViewController extends ChangeNotifier {
   BaseTalkerFilter _filter = BaseTalkerFilter();
 
-  var _expandedLogs = true;
+  bool _expandedLogs = true;
   bool _isLogOrderReversed = true;
+
+  void init({bool expandedLogs = true, isLogOrderReversed = true}){
+    _expandedLogs = expandedLogs;
+    _isLogOrderReversed = isLogOrderReversed;
+  }
 
   /// Filter for selecting specific logs and errors
   BaseTalkerFilter get filter => _filter;

--- a/packages/talker_flutter/lib/src/controller/talker_view_controller.dart
+++ b/packages/talker_flutter/lib/src/controller/talker_view_controller.dart
@@ -5,15 +5,15 @@ import 'package:talker_flutter/talker_flutter.dart';
 
 /// Controller to work with [TalkerScreen]
 class TalkerViewController extends ChangeNotifier {
-  BaseTalkerFilter _filter = BaseTalkerFilter();
-
-  bool _expandedLogs = true;
-  bool _isLogOrderReversed = true;
-
-  void init({bool expandedLogs = true, isLogOrderReversed = true}){
+  TalkerViewController({bool expandedLogs = true, isLogOrderReversed = true}){
     _expandedLogs = expandedLogs;
     _isLogOrderReversed = isLogOrderReversed;
   }
+
+  BaseTalkerFilter _filter = BaseTalkerFilter();
+
+  late bool _expandedLogs;
+  late bool _isLogOrderReversed;
 
   /// Filter for selecting specific logs and errors
   BaseTalkerFilter get filter => _filter;

--- a/packages/talker_flutter/lib/src/ui/talker_screen.dart
+++ b/packages/talker_flutter/lib/src/ui/talker_screen.dart
@@ -4,15 +4,15 @@ import 'package:talker_flutter/talker_flutter.dart';
 /// UI view for output of all Talker logs and errors
 class TalkerScreen extends StatelessWidget {
   const TalkerScreen({
-      Key? key,
-      required this.talker,
-      this.appBarTitle = 'Talker',
-      this.theme = const TalkerScreenTheme(),
-      this.itemsBuilder,
-      this.appBarLeading,
-      this.isLogsExpanded = true,
-      this.isLogOrderReversed = true,
-      }) : super(key: key);
+    Key? key,
+    required this.talker,
+    this.appBarTitle = 'Talker',
+    this.theme = const TalkerScreenTheme(),
+    this.itemsBuilder,
+    this.appBarLeading,
+    this.isLogsExpanded = true,
+    this.isLogOrderReversed = true,
+  }) : super(key: key);
 
   /// Talker implementation
   final Talker talker;
@@ -30,12 +30,10 @@ class TalkerScreen extends StatelessWidget {
   /// log items cards in list
   final TalkerDataBuilder? itemsBuilder;
 
-  /// if true, all logs will be
-  /// initially expanded
+  ///{@macro talker_flutter_is_log_exapanded}
   final bool isLogsExpanded;
 
-  /// if true, latest logs will be on the top
-  /// of the list
+  ///{@macro talker_flutter_is_log_order_reversed}
   final bool isLogOrderReversed;
 
   @override

--- a/packages/talker_flutter/lib/src/ui/talker_screen.dart
+++ b/packages/talker_flutter/lib/src/ui/talker_screen.dart
@@ -4,13 +4,15 @@ import 'package:talker_flutter/talker_flutter.dart';
 /// UI view for output of all Talker logs and errors
 class TalkerScreen extends StatelessWidget {
   const TalkerScreen({
-    Key? key,
-    required this.talker,
-    this.appBarTitle = 'Talker',
-    this.theme = const TalkerScreenTheme(),
-    this.itemsBuilder,
-    this.appBarLeading,
-  }) : super(key: key);
+      Key? key,
+      required this.talker,
+      this.appBarTitle = 'Talker',
+      this.theme = const TalkerScreenTheme(),
+      this.itemsBuilder,
+      this.appBarLeading,
+      this.isLogsExpanded = true,
+      this.isLogOrderReversed = true,
+      }) : super(key: key);
 
   /// Talker implementation
   final Talker talker;
@@ -28,6 +30,14 @@ class TalkerScreen extends StatelessWidget {
   /// log items cards in list
   final TalkerDataBuilder? itemsBuilder;
 
+  /// if true, all logs will be
+  /// initially expanded
+  final bool isLogsExpanded;
+
+  /// if true, latest logs will be on the top
+  /// of the list
+  final bool isLogOrderReversed;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -37,6 +47,8 @@ class TalkerScreen extends StatelessWidget {
         theme: theme,
         appBarTitle: appBarTitle,
         appBarLeading: appBarLeading,
+        isLogsExpanded: isLogsExpanded,
+        isLogOrderReversed: isLogOrderReversed,
       ),
     );
   }

--- a/packages/talker_flutter/lib/src/ui/talker_view.dart
+++ b/packages/talker_flutter/lib/src/ui/talker_view.dart
@@ -11,7 +11,7 @@ import 'talker_actions/talker_actions.dart';
 
 class TalkerView extends StatefulWidget {
   const TalkerView({
-      Key? key,
+    Key? key,
       required this.talker,
       this.controller,
       this.scrollController,
@@ -21,7 +21,7 @@ class TalkerView extends StatefulWidget {
       this.appBarLeading,
       this.isLogsExpanded = true,
       this.isLogOrderReversed = true
-      }) : super(key: key);
+  }) : super(key: key);
 
   /// Talker implementation
   final Talker talker;
@@ -57,15 +57,11 @@ class TalkerView extends StatefulWidget {
 
 class _TalkerViewState extends State<TalkerView> {
   final _titlesController = GroupButtonController();
-  late final _controller = widget.controller ?? TalkerViewController();
-
-  @override
-  void initState() {
-    _controller.init(
+  late final _controller = widget.controller ??
+      TalkerViewController(
         expandedLogs: widget.isLogsExpanded,
-        isLogOrderReversed: widget.isLogOrderReversed);
-    super.initState();
-  }
+        isLogOrderReversed: widget.isLogOrderReversed,
+      );
 
   @override
   Widget build(BuildContext context) {

--- a/packages/talker_flutter/lib/src/ui/talker_view.dart
+++ b/packages/talker_flutter/lib/src/ui/talker_view.dart
@@ -11,15 +11,17 @@ import 'talker_actions/talker_actions.dart';
 
 class TalkerView extends StatefulWidget {
   const TalkerView({
-    Key? key,
-    required this.talker,
-    this.controller,
-    this.scrollController,
-    this.theme = const TalkerScreenTheme(),
-    this.appBarTitle,
-    this.itemsBuilder,
-    this.appBarLeading,
-  }) : super(key: key);
+      Key? key,
+      required this.talker,
+      this.controller,
+      this.scrollController,
+      this.theme = const TalkerScreenTheme(),
+      this.appBarTitle,
+      this.itemsBuilder,
+      this.appBarLeading,
+      this.isLogsExpanded = true,
+      this.isLogOrderReversed = true
+      }) : super(key: key);
 
   /// Talker implementation
   final Talker talker;
@@ -41,6 +43,14 @@ class TalkerView extends StatefulWidget {
 
   final ScrollController? scrollController;
 
+  /// if true, all logs will be
+  /// initially expanded
+  final bool isLogsExpanded;
+
+  /// if true, latest logs will be on the top
+  /// of the list
+  final bool isLogOrderReversed;
+
   @override
   State<TalkerView> createState() => _TalkerViewState();
 }
@@ -48,6 +58,14 @@ class TalkerView extends StatefulWidget {
 class _TalkerViewState extends State<TalkerView> {
   final _titlesController = GroupButtonController();
   late final _controller = widget.controller ?? TalkerViewController();
+
+  @override
+  void initState() {
+    _controller.init(
+        expandedLogs: widget.isLogsExpanded,
+        isLogOrderReversed: widget.isLogOrderReversed);
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/packages/talker_flutter/lib/src/ui/talker_view.dart
+++ b/packages/talker_flutter/lib/src/ui/talker_view.dart
@@ -10,8 +10,8 @@ import 'package:talker_flutter/talker_flutter.dart';
 import 'talker_actions/talker_actions.dart';
 
 class TalkerView extends StatefulWidget {
-  const TalkerView({
-    Key? key,
+  const TalkerView(
+      {Key? key,
       required this.talker,
       this.controller,
       this.scrollController,
@@ -20,8 +20,8 @@ class TalkerView extends StatefulWidget {
       this.itemsBuilder,
       this.appBarLeading,
       this.isLogsExpanded = true,
-      this.isLogOrderReversed = true
-  }) : super(key: key);
+      this.isLogOrderReversed = true})
+      : super(key: key);
 
   /// Talker implementation
   final Talker talker;
@@ -43,12 +43,14 @@ class TalkerView extends StatefulWidget {
 
   final ScrollController? scrollController;
 
-  /// if true, all logs will be
-  /// initially expanded
+  /// {@template talker_flutter_is_log_exapanded}
+  /// If true, all logs will be initially expanded
+  /// {@endtemplate}
   final bool isLogsExpanded;
 
-  /// if true, latest logs will be on the top
-  /// of the list
+  /// {@template talker_flutter_is_log_order_reversed}
+  /// if true, latest logs will be on the top of the list
+  /// {@endtemplate}
   final bool isLogOrderReversed;
 
   @override


### PR DESCRIPTION
Be able to initially set  isLogsExpanded and isLogOrderReversed when open the TalkerScreen
