### PR TITLE
Add copy functionality for filtered logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Follow these steps to the coolest experience in error handling
 ### Add dependency
 ```yaml
 dependencies:
-  talker: ^4.5.5
+  talker: ^4.5.6
 ```
 
 ### Easy to use
@@ -303,7 +303,7 @@ Talker Flutter is an extension for the Dart Talker package that adds extra funct
 ### Add dependency
 ```yaml
 dependencies:
-  talker_flutter: ^4.5.5
+  talker_flutter: ^4.5.6
 ```
 
 ### Setup
@@ -532,7 +532,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_dio_logger: ^4.5.5
+  talker_dio_logger: ^4.5.6
 ```
 
 ### Usage
@@ -628,7 +628,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_bloc_logger: ^4.5.5
+  talker_bloc_logger: ^4.5.6
 ```
 
 ### Usage
@@ -716,7 +716,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_riverpod_logger: ^4.5.5
+  talker_riverpod_logger: ^4.5.6
 ```
 
 ### Usage

--- a/examples/shop_app_example/pubspec.yaml
+++ b/examples/shop_app_example/pubspec.yaml
@@ -9,9 +9,9 @@ dependencies:
   flutter:
     sdk: flutter
 
-  talker_flutter: ^4.5.5
-  talker_dio_logger: ^4.5.5
-  talker_bloc_logger: ^4.5.5
+  talker_flutter: ^4.5.6
+  talker_dio_logger: ^4.5.6
+  talker_bloc_logger: ^4.5.6
   
   get_it: ^7.6.7
   flutter_bloc: ^8.1.3

--- a/packages/talker/CHANGELOG.md
+++ b/packages/talker/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.5.6
+- [talker_flutter] Add copy functionality for filtered logs
+
+Thanks to [abdelaziz-mahdy](https://github.com/abdelaziz-mahdy)
+
 # 4.5.5
 - [talker] Add history logging filter by LogLevel
 - [talker_flutter] Fix TalkerScreen does not respect configured LogLevel setting

--- a/packages/talker/pubspec.yaml
+++ b/packages/talker/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker
 description: Advanced error handler and logger package for flutter and dart. App monitoring, logs history, report sharing, custom logs, and etc.
-version: 4.5.5
+version: 4.5.6
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
 issue_tracker: https://github.com/Frezyx/talker/issues
@@ -16,7 +16,7 @@ environment:
   sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
-  talker_logger: ^4.5.5
+  talker_logger: ^4.5.6
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/talker_bloc_logger/CHANGELOG.md
+++ b/packages/talker_bloc_logger/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.5.6
+- [talker_flutter] Add copy functionality for filtered logs
+
+Thanks to [abdelaziz-mahdy](https://github.com/abdelaziz-mahdy)
+
 # 4.5.5
 - [talker] Add history logging filter by LogLevel
 - [talker_flutter] Fix TalkerScreen does not respect configured LogLevel setting

--- a/packages/talker_bloc_logger/README.md
+++ b/packages/talker_bloc_logger/README.md
@@ -31,7 +31,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_bloc_logger: ^4.5.5
+  talker_bloc_logger: ^4.5.6
 ```
 
 ### Usage

--- a/packages/talker_bloc_logger/pubspec.yaml
+++ b/packages/talker_bloc_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_bloc_logger
 description: Lightweight and customizable BLoC state management library logger on talker base.
-version: 4.5.5
+version: 4.5.6
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
 issue_tracker: https://github.com/Frezyx/talker/issues
@@ -16,7 +16,7 @@ environment:
   sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
-  talker: ^4.5.5
+  talker: ^4.5.6
   bloc: ^8.1.1
   meta: ^1.8.0
 

--- a/packages/talker_dio_logger/CHANGELOG.md
+++ b/packages/talker_dio_logger/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.5.6
+- [talker_flutter] Add copy functionality for filtered logs
+
+Thanks to [abdelaziz-mahdy](https://github.com/abdelaziz-mahdy)
+
 # 4.5.5
 - [talker] Add history logging filter by LogLevel
 - [talker_flutter] Fix TalkerScreen does not respect configured LogLevel setting

--- a/packages/talker_dio_logger/README.md
+++ b/packages/talker_dio_logger/README.md
@@ -31,7 +31,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_dio_logger: ^4.5.5
+  talker_dio_logger: ^4.5.6
 ```
 
 ### Usage

--- a/packages/talker_dio_logger/example/pubspec.yaml
+++ b/packages/talker_dio_logger/example/pubspec.yaml
@@ -10,8 +10,8 @@ dependencies:
   flutter:
     sdk: flutter
   dio: ^5.0.0
-  talker_dio_logger: ^4.5.5
-  talker_flutter: ^4.5.5    
+  talker_dio_logger: ^4.5.6
+  talker_flutter: ^4.5.6    
 
 dev_dependencies:
   flutter_test:

--- a/packages/talker_dio_logger/pubspec.yaml
+++ b/packages/talker_dio_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_dio_logger
 description: Lightweight and customizable dio http client logger on talker base
-version: 4.5.5
+version: 4.5.6
 
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
@@ -18,7 +18,7 @@ environment:
 
 dependencies:
   dio: ^5.4.0
-  talker: ^4.5.5
+  talker: ^4.5.6
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/talker_flutter/CHANGELOG.md
+++ b/packages/talker_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.5.6
+- [talker_flutter] Add copy functionality for filtered logs
+
+Thanks to [abdelaziz-mahdy](https://github.com/abdelaziz-mahdy)
+
 # 4.5.5
 - [talker] Add history logging filter by LogLevel
 - [talker_flutter] Fix TalkerScreen does not respect configured LogLevel setting

--- a/packages/talker_flutter/lib/src/ui/talker_view.dart
+++ b/packages/talker_flutter/lib/src/ui/talker_view.dart
@@ -76,8 +76,7 @@ class _TalkerViewState extends State<TalkerView> {
           return TalkerBuilder(
             talker: widget.talker,
             builder: (context, data) {
-              final filtredElements =
-                  data.where((e) => _controller.filter.filter(e)).toList();
+              final filteredElements = filteredLogs(data);
               final titles = data.map((e) => e.title).toList();
               final uniqTitles = titles.toSet().toList();
 
@@ -104,7 +103,7 @@ class _TalkerViewState extends State<TalkerView> {
                   SliverList(
                     delegate: SliverChildBuilderDelegate(
                       (context, i) {
-                        final data = _getListItem(filtredElements, i);
+                        final data = _getListItem(filteredElements, i);
                         if (widget.itemsBuilder != null) {
                           return widget.itemsBuilder!.call(context, data);
                         }
@@ -116,7 +115,7 @@ class _TalkerViewState extends State<TalkerView> {
                           color: data.getFlutterColor(widget.theme),
                         );
                       },
-                      childCount: filtredElements.length,
+                      childCount: filteredElements.length,
                     ),
                   ),
                 ],
@@ -128,6 +127,9 @@ class _TalkerViewState extends State<TalkerView> {
     );
   }
 
+  List<TalkerData> filteredLogs(List<TalkerData> data) =>
+      data.where((e) => _controller.filter.filter(e)).toList();
+
   void _onToggleTitle(String title, bool selected) {
     if (selected) {
       _controller.addFilterTitle(title);
@@ -137,11 +139,11 @@ class _TalkerViewState extends State<TalkerView> {
   }
 
   TalkerData _getListItem(
-    List<TalkerData> filtredElements,
+    List<TalkerData> filteredElements,
     int i,
   ) {
-    final data = filtredElements[
-        _controller.isLogOrderReversed ? filtredElements.length - 1 - i : i];
+    final data = filteredElements[
+        _controller.isLogOrderReversed ? filteredElements.length - 1 - i : i];
     return data;
   }
 
@@ -204,6 +206,11 @@ class _TalkerViewState extends State<TalkerView> {
               icon: Icons.copy,
             ),
             TalkerActionItem(
+              onTap: () => _copyFilteredLogs(context),
+              title: 'Copy filtered logs',
+              icon: Icons.copy,
+            ),
+            TalkerActionItem(
               onTap: _toggleLogsExpanded,
               title: _controller.expandedLogs ? 'Collapse logs' : 'Expand logs',
               icon: _controller.expandedLogs
@@ -247,5 +254,12 @@ class _TalkerViewState extends State<TalkerView> {
         text: widget.talker.history
             .text(timeFormat: widget.talker.settings.timeFormat)));
     _showSnackBar(context, 'All logs copied in buffer');
+  }
+
+  void _copyFilteredLogs(BuildContext context) {
+    Clipboard.setData(ClipboardData(
+        text: filteredLogs(widget.talker.history)
+            .text(timeFormat: widget.talker.settings.timeFormat)));
+    _showSnackBar(context, 'All filtered logs copied in buffer');
   }
 }

--- a/packages/talker_flutter/pubspec.yaml
+++ b/packages/talker_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_flutter
 description: Advanced error handler and logger package for flutter and dart. App monitoring, logs history, report sharing, custom logs, and etc.
-version: 4.5.5
+version: 4.5.6
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
 issue_tracker: https://github.com/Frezyx/talker/issues
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  talker: ^4.5.5
+  talker: ^4.5.6
   group_button: ^5.3.4
   path_provider: ^2.1.4
   share_plus: ^10.0.1

--- a/packages/talker_http_logger/CHANGELOG.md
+++ b/packages/talker_http_logger/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.0-dev.25
+- [talker_flutter] Add copy functionality for filtered logs
+
+Thanks to [abdelaziz-mahdy](https://github.com/abdelaziz-mahdy)
+
 # 0.1.0-dev.24
 - [talker] Add history logging filter by LogLevel
 - [talker_flutter] Fix TalkerScreen does not respect configured LogLevel setting

--- a/packages/talker_http_logger/README.md
+++ b/packages/talker_http_logger/README.md
@@ -23,7 +23,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_http_logger: ^0.1.0-dev.24
+  talker_http_logger: ^0.1.0-dev.25
 ```
 
 ### Usage

--- a/packages/talker_http_logger/pubspec.yaml
+++ b/packages/talker_http_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_http_logger
 description: Lightweight and customizable http client logger on talker base
-version: 0.1.0-dev.24
+version: 0.1.0-dev.25
 homepage: https://github.com/Frezyx/talker
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   http_interceptor: ^2.0.0
-  talker: ^4.5.5
+  talker: ^4.5.6
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/talker_logger/CHANGELOG.md
+++ b/packages/talker_logger/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.5.6
+- [talker_flutter] Add copy functionality for filtered logs
+
+Thanks to [abdelaziz-mahdy](https://github.com/abdelaziz-mahdy)
+
 # 4.5.5
 - [talker] Add history logging filter by LogLevel
 - [talker_flutter] Fix TalkerScreen does not respect configured LogLevel setting

--- a/packages/talker_logger/README.md
+++ b/packages/talker_logger/README.md
@@ -23,7 +23,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_logger: ^4.5.5
+  talker_logger: ^4.5.6
 ```
 
 ### Easy to use

--- a/packages/talker_logger/pubspec.yaml
+++ b/packages/talker_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_logger
 description: Logger. Easy, customizable, extensible logging, lightweight with filters, formatters, custom logs, log levels.
-version: 4.5.5
+version: 4.5.6
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
 issue_tracker: https://github.com/Frezyx/talker/issues

--- a/packages/talker_riverpod_logger/CHANGELOG.md
+++ b/packages/talker_riverpod_logger/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.5.6
+- [talker_flutter] Add copy functionality for filtered logs
+
+Thanks to [abdelaziz-mahdy](https://github.com/abdelaziz-mahdy)
+
 # 4.5.5
 - [talker] Add history logging filter by LogLevel
 - [talker_flutter] Fix TalkerScreen does not respect configured LogLevel setting

--- a/packages/talker_riverpod_logger/README.md
+++ b/packages/talker_riverpod_logger/README.md
@@ -31,7 +31,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_riverpod_logger: ^4.5.5
+  talker_riverpod_logger: ^4.5.6
 ```
 
 ### Usage

--- a/packages/talker_riverpod_logger/example/pubspec.yaml
+++ b/packages/talker_riverpod_logger/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   freezed_annotation: ^2.0.0
   json_annotation: ^4.6.0
   riverpod: ^2.5.0
-  talker_riverpod_logger: ^4.5.5
+  talker_riverpod_logger: ^4.5.6
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/packages/talker_riverpod_logger/pubspec.yaml
+++ b/packages/talker_riverpod_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_riverpod_logger
 description: Lightweight and customizable Riverpod state management library logger on talker base.
-version: 4.5.5
+version: 4.5.6
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
 issue_tracker: https://github.com/Frezyx/talker/issues
@@ -15,7 +15,7 @@ environment:
   sdk: ">=2.15.0 <4.0.0"
 
 dependencies:
-  talker: ^4.5.5
+  talker: ^4.5.6
   riverpod: ^2.5.0
   meta: ^1.8.0
 


### PR DESCRIPTION
Adds a "Copy Filtered Logs" button to the Talker view.

As a user, I wanted to copy only the logs I had filtered but didn't find a specific button for this functionality. This pull request introduces a new action item that copies the currently filtered logs to the clipboard.

Additionally, this PR includes minor spelling corrections.