### PR TITLE
Hide specific header from http logger

### DIFF
--- a/packages/talker_http_logger/example/talker_http_logger_example.dart
+++ b/packages/talker_http_logger/example/talker_http_logger_example.dart
@@ -1,10 +1,17 @@
 import 'package:http_interceptor/http_interceptor.dart';
 import 'package:talker_http_logger/talker_http_logger.dart';
+import 'package:talker_http_logger/talker_http_logger_settings.dart';
 
 void main(List<String> args) async {
   final client = InterceptedClient.build(interceptors: [
-    TalkerHttpLogger(),
+    TalkerHttpLogger(
+        settings: TalkerHttpLoggerSettings(
+            hideHeaderValuesForKeys: {'Authorization'})),
   ]);
 
-  await client.get("https://google.com".toUri());
+  await client.get("https://google.com".toUri(), headers: {
+    "firstHeader": "firstHeaderValue",
+    "authorization": "bearer super_secret_token",
+    "lastHeader": "lastHeaderValue",
+  });
 }

--- a/packages/talker_http_logger/example/talker_http_logger_example.dart
+++ b/packages/talker_http_logger/example/talker_http_logger_example.dart
@@ -6,7 +6,7 @@ void main(List<String> args) async {
   final client = InterceptedClient.build(interceptors: [
     TalkerHttpLogger(
         settings: TalkerHttpLoggerSettings(
-            hideHeaderValuesForKeys: {'Authorization'})),
+            hiddenHeaders: {'Authorization'})),
   ]);
 
   await client.get("https://google.com".toUri(), headers: {

--- a/packages/talker_http_logger/lib/talker_http_logger.dart
+++ b/packages/talker_http_logger/lib/talker_http_logger.dart
@@ -4,20 +4,26 @@ import 'dart:convert';
 
 import 'package:http_interceptor/http_interceptor.dart';
 import 'package:talker/talker.dart';
+import 'package:talker_http_logger/talker_http_logger_settings.dart';
 
 class TalkerHttpLogger extends InterceptorContract {
-  TalkerHttpLogger({Talker? talker}) {
+  TalkerHttpLogger(
+      {Talker? talker, this.settings = const TalkerHttpLoggerSettings()}) {
     _talker = talker ?? Talker();
   }
 
   late Talker _talker;
+
+  /// [TalkerHttpLogger] settings and customization
+  TalkerHttpLoggerSettings settings;
 
   @override
   Future<BaseRequest> interceptRequest({
     required BaseRequest request,
   }) async {
     final message = '${request.url}';
-    _talker.logCustom(HttpRequestLog(message, request: request));
+    _talker.logCustom(
+        HttpRequestLog(message, request: request, settings: settings));
     return request;
   }
 
@@ -38,14 +44,18 @@ class TalkerHttpLogger extends InterceptorContract {
 }
 
 const encoder = JsonEncoder.withIndent('  ');
+const _hiddenValue = '*****';
 
 class HttpRequestLog extends TalkerLog {
   HttpRequestLog(
     String title, {
     required this.request,
+    this.settings = const TalkerHttpLoggerSettings(),
   }) : super(title);
 
   final BaseRequest request;
+
+  final TalkerHttpLoggerSettings settings;
 
   @override
   AnsiPen get pen => (AnsiPen()..xterm(219));
@@ -62,6 +72,15 @@ class HttpRequestLog extends TalkerLog {
 
     try {
       if (headers.isNotEmpty) {
+        if (settings.hideHeaderValuesForKeys.isNotEmpty) {
+          headers.updateAll((key, value) {
+            return settings.hideHeaderValuesForKeys
+                    .map((v) => v.toLowerCase())
+                    .contains(key.toLowerCase())
+                ? _hiddenValue
+                : value;
+          });
+        }
         final prettyHeaders = encoder.convert(headers);
         msg += '\nHeaders: $prettyHeaders';
       }
@@ -76,9 +95,12 @@ class HttpResponseLog extends TalkerLog {
   HttpResponseLog(
     String title, {
     required this.response,
+    this.settings = const TalkerHttpLoggerSettings(),
   }) : super(title);
 
   final BaseResponse response;
+
+  final TalkerHttpLoggerSettings settings;
 
   @override
   AnsiPen get pen => (AnsiPen()..xterm(46));
@@ -111,9 +133,12 @@ class HttpErrorLog extends TalkerLog {
   HttpErrorLog(
     String title, {
     required this.response,
+    this.settings = const TalkerHttpLoggerSettings(),
   }) : super(title);
 
   final BaseResponse response;
+
+  final TalkerHttpLoggerSettings settings;
 
   @override
   AnsiPen get pen => AnsiPen()..red();

--- a/packages/talker_http_logger/lib/talker_http_logger.dart
+++ b/packages/talker_http_logger/lib/talker_http_logger.dart
@@ -72,9 +72,9 @@ class HttpRequestLog extends TalkerLog {
 
     try {
       if (headers.isNotEmpty) {
-        if (settings.hideHeaderValuesForKeys.isNotEmpty) {
+        if (settings.hiddenHeaders.isNotEmpty) {
           headers.updateAll((key, value) {
-            return settings.hideHeaderValuesForKeys
+            return settings.hiddenHeaders
                     .map((v) => v.toLowerCase())
                     .contains(key.toLowerCase())
                 ? _hiddenValue

--- a/packages/talker_http_logger/lib/talker_http_logger_settings.dart
+++ b/packages/talker_http_logger/lib/talker_http_logger_settings.dart
@@ -1,9 +1,9 @@
 class TalkerHttpLoggerSettings {
   const TalkerHttpLoggerSettings({
-    this.hideHeaderValuesForKeys = const <String>{},
+    this.hiddenHeaders = const <String>{},
   });
 
   /// Header values for the specified keys in the Set will be replaced with *****.
   /// Case insensitive
-  final Set<String> hideHeaderValuesForKeys;
+  final Set<String> hiddenHeaders;
 }

--- a/packages/talker_http_logger/lib/talker_http_logger_settings.dart
+++ b/packages/talker_http_logger/lib/talker_http_logger_settings.dart
@@ -1,0 +1,9 @@
+class TalkerHttpLoggerSettings {
+  const TalkerHttpLoggerSettings({
+    this.hideHeaderValuesForKeys = const <String>{},
+  });
+
+  /// Header values for the specified keys in the Set will be replaced with *****.
+  /// Case insensitive
+  final Set<String> hideHeaderValuesForKeys;
+}


### PR DESCRIPTION
Added functionality based on issue #150 

Values for specified by user keys will be replaced with "*****" in header.