### PR TITLE
Hide specific header from dio logger

### DIFF
--- a/packages/talker_dio_logger/lib/dio_logs.dart
+++ b/packages/talker_dio_logger/lib/dio_logs.dart
@@ -5,6 +5,7 @@ import 'package:talker/talker.dart';
 import 'package:talker_dio_logger/talker_dio_logger.dart';
 
 const _encoder = JsonEncoder.withIndent('  ');
+const _hiddenValue = '*****';
 
 class DioRequestLog extends TalkerLog {
   DioRequestLog(
@@ -37,6 +38,15 @@ class DioRequestLog extends TalkerLog {
         msg += '\nData: $prettyData';
       }
       if (settings.printRequestHeaders && headers.isNotEmpty) {
+        if (settings.hideHeaderValuesForKeys.isNotEmpty) {
+          headers.updateAll((key, value) {
+            return settings.hideHeaderValuesForKeys
+                    .map((v) => v.toLowerCase())
+                    .contains(key.toLowerCase())
+                ? _hiddenValue
+                : value;
+          });
+        }
         final prettyHeaders = _encoder.convert(headers);
         msg += '\nHeaders: $prettyHeaders';
       }

--- a/packages/talker_dio_logger/lib/dio_logs.dart
+++ b/packages/talker_dio_logger/lib/dio_logs.dart
@@ -38,9 +38,9 @@ class DioRequestLog extends TalkerLog {
         msg += '\nData: $prettyData';
       }
       if (settings.printRequestHeaders && headers.isNotEmpty) {
-        if (settings.hideHeaderValuesForKeys.isNotEmpty) {
+        if (settings.hiddenHeaders.isNotEmpty) {
           headers.updateAll((key, value) {
-            return settings.hideHeaderValuesForKeys
+            return settings.hiddenHeaders
                     .map((v) => v.toLowerCase())
                     .contains(key.toLowerCase())
                 ? _hiddenValue

--- a/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
+++ b/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
@@ -13,6 +13,7 @@ class TalkerDioLoggerSettings {
     this.printErrorMessage = true,
     this.printRequestData = true,
     this.printRequestHeaders = false,
+    this.hideHeaderValuesForKeys = const <String>{},
     this.requestPen,
     this.responsePen,
     this.errorPen,
@@ -93,6 +94,10 @@ class TalkerDioLoggerSettings {
   /// You can add your custom logic to log only specific Dio error [DioException].
   final bool Function(DioException response)? errorFilter;
 
+  /// Header values for the specified keys in the Set will be replaced with *****.
+  /// Case insensitive
+  final Set<String> hideHeaderValuesForKeys;
+
   TalkerDioLoggerSettings copyWith({
     bool? printResponseData,
     bool? printResponseHeaders,
@@ -108,6 +113,7 @@ class TalkerDioLoggerSettings {
     bool Function(RequestOptions requestOptions)? requestFilter,
     bool Function(Response response)? responseFilter,
     bool Function(DioException response)? errorFilter,
+    Set<String>? hideHeaderValuesForKeys,
   }) {
     return TalkerDioLoggerSettings(
       printResponseData: printResponseData ?? this.printResponseData,
@@ -124,6 +130,8 @@ class TalkerDioLoggerSettings {
       requestFilter: requestFilter ?? this.requestFilter,
       responseFilter: responseFilter ?? this.responseFilter,
       errorFilter: errorFilter ?? this.errorFilter,
+      hideHeaderValuesForKeys:
+          hideHeaderValuesForKeys ?? this.hideHeaderValuesForKeys,
     );
   }
 }

--- a/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
+++ b/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
@@ -13,7 +13,7 @@ class TalkerDioLoggerSettings {
     this.printErrorMessage = true,
     this.printRequestData = true,
     this.printRequestHeaders = false,
-    this.hideHeaderValuesForKeys = const <String>{},
+    this.hiddenHeaders = const <String>{},
     this.requestPen,
     this.responsePen,
     this.errorPen,
@@ -96,7 +96,7 @@ class TalkerDioLoggerSettings {
 
   /// Header values for the specified keys in the Set will be replaced with *****.
   /// Case insensitive
-  final Set<String> hideHeaderValuesForKeys;
+  final Set<String> hiddenHeaders;
 
   TalkerDioLoggerSettings copyWith({
     bool? printResponseData,
@@ -113,7 +113,7 @@ class TalkerDioLoggerSettings {
     bool Function(RequestOptions requestOptions)? requestFilter,
     bool Function(Response response)? responseFilter,
     bool Function(DioException response)? errorFilter,
-    Set<String>? hideHeaderValuesForKeys,
+    Set<String>? hiddenHeaders,
   }) {
     return TalkerDioLoggerSettings(
       printResponseData: printResponseData ?? this.printResponseData,
@@ -130,8 +130,7 @@ class TalkerDioLoggerSettings {
       requestFilter: requestFilter ?? this.requestFilter,
       responseFilter: responseFilter ?? this.responseFilter,
       errorFilter: errorFilter ?? this.errorFilter,
-      hideHeaderValuesForKeys:
-          hideHeaderValuesForKeys ?? this.hideHeaderValuesForKeys,
+      hiddenHeaders: hiddenHeaders ?? this.hiddenHeaders,
     );
   }
 }

--- a/packages/talker_dio_logger/test/logger_test.dart
+++ b/packages/talker_dio_logger/test/logger_test.dart
@@ -68,5 +68,28 @@ void main() {
           '  ]\n'
           '}');
     });
+
+    test('onRequest method should hide specific header values in logging', () {
+      final logger = TalkerDioLogger(
+          talker: talker,
+          settings: TalkerDioLoggerSettings(printRequestHeaders: true,
+              hideHeaderValuesForKeys: {'Authorization'}));
+
+      final options = RequestOptions(path: '/test', headers: {
+        "firstHeader": "firstHeaderValue",
+        "authorization": "bearer super_secret_token",
+        "lastHeader": "lastHeaderValue",
+      });
+      logger.onRequest(options, RequestInterceptorHandler());
+      print(talker.history);
+      expect(
+          talker.history.last.generateTextMessage(),
+          '[http-request] [GET] /test\n'
+          'Headers: {\n'
+          '  "firstHeader": "firstHeaderValue",\n'
+          '  "authorization": "*****",\n'
+          '  "lastHeader": "lastHeaderValue"\n'
+          '}');
+    });
   });
 }

--- a/packages/talker_dio_logger/test/logger_test.dart
+++ b/packages/talker_dio_logger/test/logger_test.dart
@@ -73,8 +73,7 @@ void main() {
       final logger = TalkerDioLogger(
           talker: talker,
           settings: TalkerDioLoggerSettings(
-              printRequestHeaders: true,
-              hideHeaderValuesForKeys: {'Authorization'}));
+              printRequestHeaders: true, hiddenHeaders: {'Authorization'}));
 
       final options = RequestOptions(path: '/test', headers: {
         "firstHeader": "firstHeaderValue",

--- a/packages/talker_dio_logger/test/logger_test.dart
+++ b/packages/talker_dio_logger/test/logger_test.dart
@@ -72,7 +72,8 @@ void main() {
     test('onRequest method should hide specific header values in logging', () {
       final logger = TalkerDioLogger(
           talker: talker,
-          settings: TalkerDioLoggerSettings(printRequestHeaders: true,
+          settings: TalkerDioLoggerSettings(
+              printRequestHeaders: true,
               hideHeaderValuesForKeys: {'Authorization'}));
 
       final options = RequestOptions(path: '/test', headers: {


### PR DESCRIPTION
Added functionality based on issue #281 

Values for specified by user keys will be replaced with "*****" in header.