### PR TITLE
Fix search textfield background color become white in light theme

### DIFF
--- a/packages/talker_flutter/lib/src/ui/widgets/talker_view_appbar.dart
+++ b/packages/talker_flutter/lib/src/ui/widgets/talker_view_appbar.dart
@@ -184,7 +184,7 @@ class _SearchTextField extends StatelessWidget {
         ),
         onChanged: controller.updateFilterSearchQuery,
         decoration: InputDecoration(
-          fillColor: theme.cardColor,
+          fillColor: talkerTheme.backgroundColor,
           enabledBorder: OutlineInputBorder(
             borderSide: BorderSide(color: talkerTheme.textColor),
             borderRadius: BorderRadius.circular(10),


### PR DESCRIPTION
The textfield hint is always white. The background color should always black.

### Thanks a lot for contributing!<br>
Provide a description of your changes below

I use AdaptiveTheme to change light, dark theme. In light theme the cardColor attribute will be white and cause Talker search UI cannot be seen. Maybe it's proper way to set fillColor to cardColor.

<img width="259" alt="image" src="https://github.com/user-attachments/assets/a6360dd6-c011-46a7-a0f2-1317d38fee77" />
