### PR TITLE
Rename conflict extension

### DIFF
--- a/packages/talker/lib/src/extensions/extensions.dart
+++ b/packages/talker/lib/src/extensions/extensions.dart
@@ -16,7 +16,8 @@ extension TalkerIterableLogTypeModifier<TalkerLogType>
     on Iterable<TalkerLogType> {
   /// The method allows you to get the first element that satisfies the condition
   /// or null if no element satisfies the condition.
-  TalkerLogType? firstWhereOrNull(bool Function(TalkerLogType element) test) =>
+  TalkerLogType? firstWhereLogTypeOrNull(
+          bool Function(TalkerLogType element) test) =>
       cast<TalkerLogType?>()
           .firstWhere((v) => v != null && test(v), orElse: () => null);
 }

--- a/packages/talker/lib/src/talker_key.dart
+++ b/packages/talker/lib/src/talker_key.dart
@@ -38,7 +38,7 @@ enum TalkerLogType {
   }
 
   static TalkerLogType? fromKey(String key) {
-    return TalkerLogType.values.firstWhereOrNull((e) => e.key == key);
+    return TalkerLogType.values.firstWhereLogTypeOrNull((e) => e.key == key);
   }
 }
 


### PR DESCRIPTION
talker: 
 - Fixed conflicting with `collection` package or local project extensions. Renamed method firstWhereOrNull to more specific name.
 
![image](https://github.com/user-attachments/assets/6b92d9cf-839a-4241-acfe-f3463a0aa594)
