### PR TITLE
Fix search filtering rules

### DIFF
--- a/packages/talker/lib/src/filter.dart
+++ b/packages/talker/lib/src/filter.dart
@@ -34,7 +34,8 @@ class BaseTalkerFilter implements TalkerFilter {
             fullLowerMsg.contains(searchQuery!);
       }
 
-      return (titles.contains(item.title) || _checkTypeMatch(item)) &&
+      return (titles.contains(item.title) || titles.isEmpty) &&
+          (_checkTypeMatch(item) || types.isEmpty) &&
           (match || (searchQuery?.isEmpty ?? true));
     }
   }

--- a/packages/talker/lib/src/filter.dart
+++ b/packages/talker/lib/src/filter.dart
@@ -21,29 +21,22 @@ class BaseTalkerFilter implements TalkerFilter {
 
   @override
   bool filter(TalkerData item) {
-    var match = false;
-
-    if (titles.isNotEmpty) {
-      match = match || titles.contains(item.title);
-    }
-
-    if (types.isNotEmpty) {
-      match = match || _checkTypeMatch(item);
-    }
-
-    if (searchQuery?.isNotEmpty ?? false) {
-      final fullMsg = item.generateTextMessage();
-      final fullUpperMsg = fullMsg.toUpperCase();
-      final fullLowerMsg = fullMsg.toLowerCase();
-      final textContain = fullUpperMsg.contains(searchQuery!) ||
-          fullLowerMsg.contains(searchQuery!);
-      match = match || textContain;
-    }
-
     if (titles.isEmpty && types.isEmpty && (searchQuery?.isEmpty ?? true)) {
-      match = true;
+      return true;
+    } else {
+      var match = false;
+
+      if (searchQuery?.isNotEmpty ?? false) {
+        final fullMsg = item.generateTextMessage();
+        final fullUpperMsg = fullMsg.toUpperCase();
+        final fullLowerMsg = fullMsg.toLowerCase();
+        match = fullUpperMsg.contains(searchQuery!) ||
+            fullLowerMsg.contains(searchQuery!);
+      }
+
+      return (titles.contains(item.title) || _checkTypeMatch(item)) &&
+          (match || (searchQuery?.isEmpty ?? true));
     }
-    return match;
   }
 
   bool _checkTypeMatch(TalkerData item) {

--- a/packages/talker/test/filter_test.dart
+++ b/packages/talker/test/filter_test.dart
@@ -150,7 +150,6 @@ void _testFilterFoundBySearchText({
         ? talker.history
         : talker.history.where((e) => filter.filter(e)).toList();
 
-    expect(foundRecords, isNotEmpty);
     expect(foundRecords.length, countFound);
   });
 }


### PR DESCRIPTION
Using filters with search bar you get their union instead of intersection, so u cant reduce result list using them at the same time.
