### PR TITLE
bugfix/web_encoding: fix web specific encoding issue

### DIFF
--- a/packages/talker_logger/lib/src/logger_web.dart
+++ b/packages/talker_logger/lib/src/logger_web.dart
@@ -2,5 +2,9 @@ import 'dart:js_interop';
 
 import 'package:web/web.dart';
 
-void outputLog(String message) =>
-    message.split('\n').forEach((it) => console.log(it.toJS));
+// Note: \uFFFD is a special character that can cause a crash on web when logged
+// Encountered while logging some italian stuff with accents (èéàùìò), not always happening
+// Probably related to enconding issues.
+void outputLog(String message) => message
+    .split('\n')
+    .forEach((it) => console.log(it.replaceAll('\uFFFD', '').toJS));


### PR DESCRIPTION
This PR solves an encoding issue encountered on web where some special accented characters (i.e. èéàùìò) would translate to `\uFFFD` (�) which would make the app crash when trying to log it to the web console.