### PR TITLE
Add response time to logs in talker_dio_logger

### DIFF
--- a/packages/talker_dio_logger/lib/dio_logs.dart
+++ b/packages/talker_dio_logger/lib/dio_logs.dart
@@ -7,7 +7,7 @@ import 'package:talker_dio_logger/talker_dio_logger.dart';
 const _encoder = JsonEncoder.withIndent('  ');
 const _hiddenValue = '*****';
 
-const kDioLogsTimeStampKey = '_talker_dio_logger_ts_';
+
 
 class DioRequestLog extends TalkerLog {
   DioRequestLog(
@@ -90,9 +90,7 @@ class DioResponseLog extends TalkerLog {
   String generateTextMessage({
     TimeFormat timeFormat = TimeFormat.timeAndSeconds,
   }) {
-    final responseTime = _getResponseTime(response.requestOptions);
-
-    var msg = '[$title] [${response.requestOptions.method}] [$responseTime ms] $message';
+    var msg = '[$title] [${response.requestOptions.method}] $message';
 
     final responseMessage = response.statusMessage;
     final data = response.data;
@@ -100,6 +98,14 @@ class DioResponseLog extends TalkerLog {
     final redirects = response.redirects;
 
     msg += '\nStatus: ${response.statusCode}';
+
+    if (settings.printResponseTime) {
+      final responseTime = _getResponseTime(response.requestOptions);
+
+      if (responseTime != null) {
+        msg += '\nTime: $responseTime ms';
+      }
+    }
 
     if (settings.printResponseMessage && responseMessage != null) {
       msg += '\nMessage: $responseMessage';
@@ -148,9 +154,7 @@ class DioErrorLog extends TalkerLog {
   String generateTextMessage({
     TimeFormat timeFormat = TimeFormat.timeAndSeconds,
   }) {
-    final responseTime = _getResponseTime(dioException.requestOptions);
-
-    var msg = '[$title] [${dioException.requestOptions.method}] [$responseTime ms] $message';
+    var msg = '[$title] [${dioException.requestOptions.method}] $message';
 
     final responseMessage = dioException.message;
     final statusCode = dioException.response?.statusCode;
@@ -159,6 +163,14 @@ class DioErrorLog extends TalkerLog {
 
     if (statusCode != null) {
       msg += '\nStatus: ${dioException.response?.statusCode}';
+    }
+
+    if (settings.printResponseTime) {
+      final responseTime = _getResponseTime(dioException.requestOptions);
+
+      if (responseTime != null) {
+        msg += '\nTime: $responseTime ms';
+      }
     }
 
     if (settings.printErrorMessage && responseMessage != null) {
@@ -180,12 +192,12 @@ class DioErrorLog extends TalkerLog {
 ///
 /// Get response time
 ///
-int _getResponseTime(RequestOptions options) {
-  final triggerTime = options.extra[kDioLogsTimeStampKey];
+int? _getResponseTime(RequestOptions options) {
+  final triggerTime = options.extra[TalkerDioLogger.kDioLogsTimeStampKey];
 
   if (triggerTime is int) {
     return DateTime.now().millisecondsSinceEpoch - triggerTime;
   }
 
-  return -1;
+  return null;
 }

--- a/packages/talker_dio_logger/lib/dio_logs.dart
+++ b/packages/talker_dio_logger/lib/dio_logs.dart
@@ -7,6 +7,8 @@ import 'package:talker_dio_logger/talker_dio_logger.dart';
 const _encoder = JsonEncoder.withIndent('  ');
 const _hiddenValue = '*****';
 
+const kDioLogsTimeStampKey = '_talker_dio_logger_ts_';
+
 class DioRequestLog extends TalkerLog {
   DioRequestLog(
     String message, {
@@ -88,7 +90,9 @@ class DioResponseLog extends TalkerLog {
   String generateTextMessage({
     TimeFormat timeFormat = TimeFormat.timeAndSeconds,
   }) {
-    var msg = '[$title] [${response.requestOptions.method}] $message';
+    final responseTime = _getResponseTime(response.requestOptions);
+
+    var msg = '[$title] [${response.requestOptions.method}] [$responseTime ms] $message';
 
     final responseMessage = response.statusMessage;
     final data = response.data;
@@ -144,7 +148,9 @@ class DioErrorLog extends TalkerLog {
   String generateTextMessage({
     TimeFormat timeFormat = TimeFormat.timeAndSeconds,
   }) {
-    var msg = '[$title] [${dioException.requestOptions.method}] $message';
+    final responseTime = _getResponseTime(dioException.requestOptions);
+
+    var msg = '[$title] [${dioException.requestOptions.method}] [$responseTime ms] $message';
 
     final responseMessage = dioException.message;
     final statusCode = dioException.response?.statusCode;
@@ -169,4 +175,17 @@ class DioErrorLog extends TalkerLog {
     }
     return msg;
   }
+}
+
+///
+/// Get response time
+///
+int _getResponseTime(RequestOptions options) {
+  final triggerTime = options.extra[kDioLogsTimeStampKey];
+
+  if (triggerTime is int) {
+    return DateTime.now().millisecondsSinceEpoch - triggerTime;
+  }
+
+  return -1;
 }

--- a/packages/talker_dio_logger/lib/talker_dio_logger_interceptor.dart
+++ b/packages/talker_dio_logger/lib/talker_dio_logger_interceptor.dart
@@ -17,6 +17,8 @@ class TalkerDioLogger extends Interceptor {
     _talker = talker ?? Talker();
   }
 
+  static const kDioLogsTimeStampKey = '_talker_dio_logger_ts_';
+
   late Talker _talker;
 
   /// [TalkerDioLogger] settings and customization
@@ -60,7 +62,11 @@ class TalkerDioLogger extends Interceptor {
     RequestOptions options,
     RequestInterceptorHandler handler,
   ) {
-    options.extra[kDioLogsTimeStampKey] = DateTime.now().millisecondsSinceEpoch;
+    if (settings.enabled && settings.printResponseTime) {
+      options.extra[kDioLogsTimeStampKey] = DateTime
+          .now()
+          .millisecondsSinceEpoch;
+    }
 
     super.onRequest(options, handler);
     if (!settings.enabled) {

--- a/packages/talker_dio_logger/lib/talker_dio_logger_interceptor.dart
+++ b/packages/talker_dio_logger/lib/talker_dio_logger_interceptor.dart
@@ -60,6 +60,8 @@ class TalkerDioLogger extends Interceptor {
     RequestOptions options,
     RequestInterceptorHandler handler,
   ) {
+    options.extra[kDioLogsTimeStampKey] = DateTime.now().millisecondsSinceEpoch;
+
     super.onRequest(options, handler);
     if (!settings.enabled) {
       return;

--- a/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
+++ b/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
@@ -9,6 +9,7 @@ class TalkerDioLoggerSettings {
     this.printResponseHeaders = false,
     this.printResponseMessage = true,
     this.printResponseRedirects = false,
+    this.printResponseTime = false,
     this.printErrorData = true,
     this.printErrorHeaders = true,
     this.printErrorMessage = true,
@@ -37,6 +38,9 @@ class TalkerDioLoggerSettings {
 
   /// Print [response.redirects] if true
   final bool printResponseRedirects;
+
+  /// Print response time if true
+  final bool printResponseTime;
 
   /// Print [error.response.data] if true
   final bool printErrorData;
@@ -106,6 +110,7 @@ class TalkerDioLoggerSettings {
     bool? printResponseData,
     bool? printResponseHeaders,
     bool? printResponseMessage,
+    bool? printResponseTime,
     bool? printErrorData,
     bool? printErrorHeaders,
     bool? printErrorMessage,
@@ -123,6 +128,7 @@ class TalkerDioLoggerSettings {
       printResponseData: printResponseData ?? this.printResponseData,
       printResponseHeaders: printResponseHeaders ?? this.printResponseHeaders,
       printResponseMessage: printResponseMessage ?? this.printResponseMessage,
+      printResponseTime: printResponseTime ?? this.printResponseTime,
       printErrorData: printErrorData ?? this.printErrorData,
       printErrorHeaders: printErrorHeaders ?? this.printErrorHeaders,
       printErrorMessage: printErrorMessage ?? this.printErrorMessage,

--- a/packages/talker_dio_logger/test/logs_test.dart
+++ b/packages/talker_dio_logger/test/logs_test.dart
@@ -154,6 +154,80 @@ void main() {
     });
 
     test(
+        'generateTextMessage should include response time if printResponseTime is true',
+        () {
+      final response = Response(
+        requestOptions: RequestOptions(path: '/test', method: 'GET', extra: {
+          TalkerDioLogger.kDioLogsTimeStampKey:
+              DateTime.now().millisecondsSinceEpoch,
+        }),
+        statusCode: 200,
+        statusMessage: 'OK',
+      );
+      final settings = TalkerDioLoggerSettings(printResponseTime: true);
+      final dioResponseLog = DioResponseLog(
+        'Test message',
+        response: response,
+        settings: settings,
+      );
+
+      final result = dioResponseLog.generateTextMessage();
+
+      expect(result, matches(RegExp(r'Time: \d+ ms')));
+    });
+
+    test(
+        'generateTextMessage should not include response time if printResponseTime is false',
+        () {
+      final response = Response(
+        requestOptions: RequestOptions(path: '/test', method: 'GET', extra: {
+          TalkerDioLogger.kDioLogsTimeStampKey:
+              DateTime.now().millisecondsSinceEpoch,
+        }),
+        statusCode: 200,
+        statusMessage: 'OK',
+      );
+      final settings = TalkerDioLoggerSettings(printResponseTime: false);
+      final dioResponseLog = DioResponseLog(
+        'Test message',
+        response: response,
+        settings: settings,
+      );
+
+      final result = dioResponseLog.generateTextMessage();
+
+      expect(result, isNot(contains('Time:')));
+    });
+
+    test(
+        'generateTextMessage error should include include response time if printResponseTime is true',
+        () {
+      final response = Response(
+        requestOptions: RequestOptions(path: '/test', method: 'GET', extra: {
+          TalkerDioLogger.kDioLogsTimeStampKey:
+              DateTime.now().millisecondsSinceEpoch,
+        }),
+        statusCode: 404,
+      );
+      final dioException = DioException(
+        requestOptions: RequestOptions(path: '/test', method: 'GET', extra: {
+          TalkerDioLogger.kDioLogsTimeStampKey:
+              DateTime.now().millisecondsSinceEpoch,
+        }),
+        response: response,
+        message: 'Error message',
+      );
+
+      final settings = TalkerDioLoggerSettings(printResponseTime: true);
+      final dioErrorLog = DioErrorLog('Error title',
+          dioException: dioException, settings: settings);
+
+      final result = dioErrorLog.generateTextMessage();
+
+      expect(result, matches(RegExp(r'Time: \d+ ms')));
+    });
+
+    test(
         'generateTextMessage should include headers if printResponseHeaders is true',
         () {
       final response = Response(


### PR DESCRIPTION
The changes add the response time to the logs generated by the talker_dio_logger package. 
The `DioRequestLog` and `DioErrorLog` classes now display the response time.

Example: `[http-response] [GET] [137 ms] https://domain.com/api/users`

## Summary by Sourcery

Add response time tracking to Dio logger logs

New Features:
- Implement response time measurement for Dio logger logs, displaying time taken for each request

Enhancements:
- Modify logging to include response time in milliseconds for HTTP requests and errors