### PR TITLE
Fixed missing info and detailed message for exceptions

### DIFF
--- a/packages/talker_flutter/lib/src/ui/widgets/data_card.dart
+++ b/packages/talker_flutter/lib/src/ui/widgets/data_card.dart
@@ -181,9 +181,6 @@ class _TalkerDataCardState extends State<TalkerDataCard> {
   }
 
   String? get _message {
-    if (widget.data is TalkerError || widget.data is TalkerException) {
-      return null;
-    }
     final isHttpLog = [
       TalkerLogType.httpError.key,
       TalkerLogType.httpRequest.key,
@@ -197,7 +194,7 @@ class _TalkerDataCardState extends State<TalkerDataCard> {
 
   String? get _errorMessage {
     var txt =
-        widget.data.exception?.toString() ?? widget.data.exception?.toString();
+        widget.data.exception?.toString() ?? widget.data.error?.toString();
 
     if ((txt?.isNotEmpty ?? false) && txt!.contains('Source stack:')) {
       txt = 'Data: ${txt.split('Source stack:').first.replaceAll('\n', '')}';


### PR DESCRIPTION
This fixes display of errors/exceptions in the TalkerScreen.

The `_message` getter was being set to null in case of Error/Exception. But there is a helpful message that describes the exception (e.g. Uncaught app exception) that should be displayed.

Also, there was a typing error for the `_errorMessage` getter. This was not allowing the specific error message to go through.

Before the fix:
![before-fix](https://github.com/user-attachments/assets/034b289a-823d-404b-bfd3-a4b40d3fc80f)

After the fix:
![fixed](https://github.com/user-attachments/assets/0f294c87-a318-4b87-9b8d-927c657ff4d3)

## Summary by Sourcery

Fix error message display in TalkerScreen by correcting message retrieval for errors and exceptions

Bug Fixes:
- Corrected the `_message` getter to not return null for errors and exceptions
- Fixed a typing error in the `_errorMessage` getter to properly retrieve error or exception messages