### PR TITLE
[talker_riverpod_logger] add support for Riverpod 3.0.0(-Dev)

### DIFF
--- a/packages/talker_riverpod_logger/example/pubspec.yaml
+++ b/packages/talker_riverpod_logger/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   dio: ^5.1.1
   freezed_annotation: ^3.0.0
   json_annotation: ^4.7.5
-  riverpod: ^2.5.0
+  riverpod: ">=3.0.0-Dev <4.0.0"
   talker_riverpod_logger: ^4.7.5
 
 dev_dependencies:

--- a/packages/talker_riverpod_logger/lib/riverpod_logs.dart
+++ b/packages/talker_riverpod_logger/lib/riverpod_logs.dart
@@ -1,4 +1,4 @@
-import 'package:riverpod/riverpod.dart';
+import 'package:riverpod/misc.dart';
 import 'package:talker/talker.dart';
 import 'package:talker_riverpod_logger/talker_riverpod_logger.dart';
 

--- a/packages/talker_riverpod_logger/lib/talker_riverpod_logger_observer.dart
+++ b/packages/talker_riverpod_logger/lib/talker_riverpod_logger_observer.dart
@@ -22,21 +22,20 @@ class TalkerRiverpodObserver extends ProviderObserver {
   @override
   @mustCallSuper
   void didAddProvider(
-    ProviderBase<Object?> provider,
-    Object? value,
-    ProviderContainer container,
+      ProviderObserverContext context,
+      Object? value,
   ) {
-    super.didAddProvider(provider, value, container);
+    super.didAddProvider(context,value);
     if (!settings.enabled || !settings.printProviderAdded) {
       return;
     }
-    final accepted = settings.providerFilter?.call(provider) ?? true;
+    final accepted = settings.providerFilter?.call(context.provider) ?? true;
     if (!accepted) {
       return;
     }
     _talker.logCustom(
       RiverpodAddLog(
-        provider: provider,
+        provider: context.provider,
         value: value,
         settings: settings,
       ),
@@ -46,22 +45,21 @@ class TalkerRiverpodObserver extends ProviderObserver {
   @override
   @mustCallSuper
   void didUpdateProvider(
-    ProviderBase<Object?> provider,
-    Object? previousValue,
-    Object? newValue,
-    ProviderContainer container,
+      ProviderObserverContext context,
+      Object? previousValue,
+      Object? newValue,
   ) {
-    super.didUpdateProvider(provider, previousValue, newValue, container);
+    super.didUpdateProvider(context, previousValue, newValue);
     if (!settings.enabled || !settings.printProviderUpdated) {
       return;
     }
-    final accepted = settings.providerFilter?.call(provider) ?? true;
+    final accepted = settings.providerFilter?.call(context.provider) ?? true;
     if (!accepted) {
       return;
     }
     _talker.logCustom(
       RiverpodUpdateLog(
-        provider: provider,
+        provider: context.provider,
         previousValue: previousValue,
         newValue: newValue,
         settings: settings,
@@ -72,20 +70,19 @@ class TalkerRiverpodObserver extends ProviderObserver {
   @override
   @mustCallSuper
   void didDisposeProvider(
-    ProviderBase<Object?> provider,
-    ProviderContainer container,
+      ProviderObserverContext context,
   ) {
-    super.didDisposeProvider(provider, container);
+    super.didDisposeProvider(context);
     if (!settings.enabled || !settings.printProviderDisposed) {
       return;
     }
-    final accepted = settings.providerFilter?.call(provider) ?? true;
+    final accepted = settings.providerFilter?.call(context.provider) ?? true;
     if (!accepted) {
       return;
     }
     _talker.logCustom(
       RiverpodDisposeLog(
-        provider: provider,
+        provider: context.provider,
         settings: settings,
       ),
     );
@@ -94,22 +91,21 @@ class TalkerRiverpodObserver extends ProviderObserver {
   @override
   @mustCallSuper
   void providerDidFail(
-    ProviderBase<Object?> provider,
+      ProviderObserverContext context,
     Object error,
     StackTrace stackTrace,
-    ProviderContainer container,
   ) {
-    super.providerDidFail(provider, error, stackTrace, container);
+    super.providerDidFail(context, error, stackTrace);
     if (!settings.enabled || !settings.printProviderFailed) {
       return;
     }
-    final accepted = settings.providerFilter?.call(provider) ?? true;
+    final accepted = settings.providerFilter?.call(context.provider) ?? true;
     if (!accepted) {
       return;
     }
     _talker.logCustom(
       RiverpodFailLog(
-        provider: provider,
+        provider: context.provider,
         providerError: error,
         providerStackTrace: stackTrace,
         settings: settings,

--- a/packages/talker_riverpod_logger/lib/talker_riverpod_logger_settings.dart
+++ b/packages/talker_riverpod_logger/lib/talker_riverpod_logger_settings.dart
@@ -1,4 +1,4 @@
-import 'package:riverpod/riverpod.dart';
+import 'package:riverpod/misc.dart';
 
 class TalkerRiverpodLoggerSettings {
   const TalkerRiverpodLoggerSettings({

--- a/packages/talker_riverpod_logger/pubspec.yaml
+++ b/packages/talker_riverpod_logger/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 
 dependencies:
   talker: ^4.7.5
-  riverpod: ^2.5.0
+  riverpod: ">=3.0.0-Dev <4.0.0"
   meta: ^1.8.0
 
 dev_dependencies:

--- a/packages/talker_riverpod_logger/test/logs_test.dart
+++ b/packages/talker_riverpod_logger/test/logs_test.dart
@@ -1,3 +1,4 @@
+import 'package:riverpod/legacy.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:talker/talker.dart';
 import 'package:talker_riverpod_logger/talker_riverpod_logger.dart';

--- a/packages/talker_riverpod_logger/test/observer_test.dart
+++ b/packages/talker_riverpod_logger/test/observer_test.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: invalid_use_of_protected_member, override_on_non_overriding_member
 
+import 'package:riverpod/legacy.dart';
 import 'package:riverpod/riverpod.dart';
 import 'package:talker/talker.dart';
 import 'package:talker_riverpod_logger/talker_riverpod_logger.dart';


### PR DESCRIPTION
There is new Riverpod 3.0.0 release in near future, that contain breaking changes to the Provider Observers. 
This PR request update package code to work with 3.0.0-Dev version that currently published (should work with release version once published as well)