### PR TITLE
fix: propagate `itemsBuilder` to `TalkerView`

### DIFF
--- a/packages/talker_flutter/lib/src/ui/talker_screen.dart
+++ b/packages/talker_flutter/lib/src/ui/talker_screen.dart
@@ -42,6 +42,7 @@ class TalkerScreen extends StatelessWidget {
       backgroundColor: theme.backgroundColor,
       body: TalkerView(
         talker: talker,
+        itemsBuilder: itemsBuilder,
         theme: theme,
         appBarTitle: appBarTitle,
         appBarLeading: appBarLeading,


### PR DESCRIPTION
This fixes the issue where `itemsBuilder` has no effect for the client

### Thanks a lot for contributing!<br>
I've only passed the itemsBuilder to the TalkerView to make it usable

## Summary by Sourcery

Bug Fixes:
- Fixed issue where `itemsBuilder` had no effect in the TalkerScreen