### PR TITLE
fix: respect custom `TalkerLogger` output in `TalkerFlutter.init`

### DIFF
--- a/packages/talker_flutter/lib/src/extensions/talker_flutter.dart
+++ b/packages/talker_flutter/lib/src/extensions/talker_flutter.dart
@@ -1,4 +1,4 @@
-import 'dart:developer';
+import 'dart:developer' show log;
 
 import 'package:flutter/foundation.dart';
 import 'package:talker_flutter/talker_flutter.dart';
@@ -11,25 +11,30 @@ extension TalkerFlutter on Talker {
     TalkerFilter? filter,
   }) =>
       Talker(
-        logger: (logger ?? TalkerLogger()).copyWith(
-          output: _defaultFlutterOutput,
-        ),
-        settings: settings,
+        logger: logger ?? TalkerLogger(output: _defaultFlutterOutput),
         observer: observer,
+        settings: settings,
         filter: filter,
       );
 
-  static dynamic _defaultFlutterOutput(String message) {
+  /// Default output function for Flutter:
+  /// - On web, prints to console.
+  /// - On iOS/macOS, uses `dart:developer.log`.
+  /// - On other platforms, uses `debugPrint`.
+  static void _defaultFlutterOutput(String message) {
     if (kIsWeb) {
       // ignore: avoid_print
       print(message);
       return;
     }
-    if ([TargetPlatform.iOS, TargetPlatform.macOS]
-        .contains(defaultTargetPlatform)) {
-      log(message, name: 'Talker');
-      return;
+
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        log(message, name: 'Talker');
+        break;
+      default:
+        debugPrint(message);
     }
-    debugPrint(message);
   }
 }

--- a/packages/talker_flutter/pubspec_overrides.yaml
+++ b/packages/talker_flutter/pubspec_overrides.yaml
@@ -2,3 +2,6 @@ dependency_overrides:
   talker:
     path:
       ../talker
+  talker_logger:
+    path:
+      ../talker_logger


### PR DESCRIPTION
This change fixes the issue #365 where passing a custom `TalkerLogger` into `TalkerFlutter.init` would still have its output callback unconditionally overridden by the default Flutter output function. Now, if you supply your own `TalkerLogger`, its output delegate is used verbatim; the default only applies when you don’t pass any logger at all.

### Before
```dart
// Always overwrote custom logger.output:
Talker(
  logger: (logger ?? TalkerLogger()).copyWith(
    output: _defaultFlutterOutput,
  ),
  …
);
```

- Even if you passed in a TalkerLogger(output: myOutput), .copyWith(output: _defaultFlutterOutput) forced it back to the default.
### After

```dart
// Only uses default output when no logger is provided:
Talker(
  logger: logger ?? TalkerLogger(output: _defaultFlutterOutput),
  …
);
```

- __Custom logger:__ `Talker.init(logger: customLogger)` -> uses customLogger.output unchanged.
- __No logger:__ defaults to `TalkerLogger(output: _defaultFlutterOutput`) for platform-aware printing.

### Benefits:
- Allows full customization of logging behavior without being overridden.
- Maintains existing default behavior for callers who don’t provide a logger.
- Simplifies the initialization logic by removing an unnecessary copyWith.

---

__tl;dr__ fixes #365

## Summary by Sourcery

Fix the handling of custom TalkerLogger output in TalkerFlutter initialization to respect user-provided logging configurations

New Features:
- Add support for preserving custom logger output configurations

Bug Fixes:
- Prevent unconditional overriding of custom logger output in TalkerFlutter.init
- Ensure custom logger output is used when provided

Enhancements:
- Improve platform-specific logging output handling
- Simplify logger initialization logic