### PR TITLE
chore: update share_plus to v11.0.0

### DIFF
--- a/packages/talker_flutter/lib/src/utils/download_logs/download_logs_native.dart
+++ b/packages/talker_flutter/lib/src/utils/download_logs/download_logs_native.dart
@@ -10,5 +10,7 @@ Future<void> downloadFile(String logs) async {
   final file =
       await File('$dirPath/talker_logs_$fmtDate.txt').create(recursive: true);
   await file.writeAsString(logs);
-  await Share.shareXFiles(<XFile>[XFile(file.path)]);
+  await SharePlus.instance.share(
+    ShareParams(files: <XFile>[XFile(file.path)]),
+  );
 }

--- a/packages/talker_flutter/pubspec.yaml
+++ b/packages/talker_flutter/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   talker: ^4.7.6
   group_button: ^5.3.4
   path_provider: ^2.1.4
-  share_plus: ^10.0.1
+  share_plus: ^11.0.0
   web: ^1.1.0
 
 


### PR DESCRIPTION
The latest version of `share_plus` deprecated some methods [in favor of a new recommended one](https://pub.dev/packages/share_plus#migrating-from-shareshare-to-shareplusinstanceshare). This PR updates the dependency and replaces the deprecated method with the recommended one.

This is to avoid version conflicts for projects that depend on both `share_plus` and `talker_flutter`.

## Summary by Sourcery

Update the share_plus dependency to v11.0.0 and replace the deprecated shareXFiles call with the new SharePlus.instance.share API.

Enhancements:
- Replace deprecated Share.shareXFiles with SharePlus.instance.share using ShareParams

Build:
- Bump share_plus dependency to version 11.0.0