### PR TITLE
[talker_riverpod_logger] add an error filter

### DIFF
--- a/packages/talker_riverpod_logger/lib/talker_riverpod_logger_observer.dart
+++ b/packages/talker_riverpod_logger/lib/talker_riverpod_logger_observer.dart
@@ -108,8 +108,12 @@ class TalkerRiverpodObserver extends ProviderObserver {
       return;
     }
 
-    final errorFiltered = settings.didFailFilter?.call(error) ?? true;
-    if (!errorFiltered) {
+    try {
+      final errorFiltered = settings.didFailFilter?.call(error) ?? true;
+      if (!errorFiltered) {
+        return;
+      }
+    } catch (_) {
       return;
     }
 

--- a/packages/talker_riverpod_logger/lib/talker_riverpod_logger_observer.dart
+++ b/packages/talker_riverpod_logger/lib/talker_riverpod_logger_observer.dart
@@ -107,6 +107,12 @@ class TalkerRiverpodObserver extends ProviderObserver {
     if (!accepted) {
       return;
     }
+
+    final errorFiltered = settings.didFailFilter?.call(error) ?? true;
+    if (!errorFiltered) {
+      return;
+    }
+
     _talker.logCustom(
       RiverpodFailLog(
         provider: provider,

--- a/packages/talker_riverpod_logger/lib/talker_riverpod_logger_settings.dart
+++ b/packages/talker_riverpod_logger/lib/talker_riverpod_logger_settings.dart
@@ -9,6 +9,7 @@ class TalkerRiverpodLoggerSettings {
     this.printProviderFailed = true,
     this.printStateFullData = true,
     this.printFailFullData = true,
+    this.didFailFilter,
     this.providerFilter,
   });
 
@@ -19,5 +20,6 @@ class TalkerRiverpodLoggerSettings {
   final bool printProviderFailed;
   final bool printStateFullData;
   final bool printFailFullData;
+  final bool Function(Object error)? didFailFilter;
   final bool Function(ProviderBase<Object?> provider)? providerFilter;
 }

--- a/packages/talker_riverpod_logger/test/observer_test.dart
+++ b/packages/talker_riverpod_logger/test/observer_test.dart
@@ -89,5 +89,29 @@ void main() {
       final log = talker.history.first;
       expect(log.generateTextMessage(), contains('failed'));
     });
+
+    test('providerDidFail with filter', () async {
+      talkerRiverpodObserver = TalkerRiverpodObserver(
+        talker: talker,
+        settings: TalkerRiverpodLoggerSettings(
+          enabled: true,
+          printProviderDisposed: true,
+          didFailFilter: (error) {
+            if (error is Exception) return true;
+            return false;
+          },
+        ),
+      );
+      container = createContainer(
+        observers: [talkerRiverpodObserver],
+        overrides: [
+          provider.overrideWith((ref) => TestNotifier()),
+        ],
+      );
+      container.read(errorProvider);
+      await Future.delayed(const Duration(milliseconds: 10));
+      final log = talker.history;
+      expect(log.whereType<RiverpodFailLog>(), isEmpty);
+    });
   });
 }


### PR DESCRIPTION
solves #335

## Summary by Sourcery

Add support for filtering error logs in TalkerRiverpodLogger by introducing a didFailFilter callback and applying it in the observer.

New Features:
- Introduce a didFailFilter predicate in TalkerRiverpodLoggerSettings to allow conditional logging of errors
- Apply the didFailFilter in TalkerRiverpodObserver to skip logging when the filter returns false