### PR TITLE
fix: add missing error and exception details to console logs

### DIFF
--- a/packages/talker/lib/src/models/talker_data.dart
+++ b/packages/talker/lib/src/models/talker_data.dart
@@ -72,7 +72,7 @@ class TalkerData {
   /// {@endtemplate}
   String generateTextMessage(
       {TimeFormat timeFormat = TimeFormat.timeAndSeconds}) {
-    return '${displayTitleWithTime(timeFormat: timeFormat)}$message$displayStackTrace';
+    return '${displayTitleWithTime(timeFormat: timeFormat)}$displayMessage$displayException$displayError$displayStackTrace';
   }
 }
 

--- a/packages/talker/lib/src/models/talker_log.dart
+++ b/packages/talker/lib/src/models/talker_log.dart
@@ -19,6 +19,6 @@ class TalkerLog extends TalkerData {
   @override
   String generateTextMessage(
       {TimeFormat timeFormat = TimeFormat.timeAndSeconds}) {
-    return '${displayTitleWithTime(timeFormat: timeFormat)}$displayMessage$displayException$displayStackTrace';
+    return '${displayTitleWithTime(timeFormat: timeFormat)}$displayMessage$displayException$displayError$displayStackTrace';
   }
 }

--- a/packages/talker/test/talker_data_models_test.dart
+++ b/packages/talker/test/talker_data_models_test.dart
@@ -65,22 +65,39 @@ Exception''',
     });
 
     test('TalkerLog', () async {
+      final error = Error();
+      final exception = Exception('Test Exception');
+      final dateTime = DateTime.now();
       final log = TalkerLog(
         _testMessage,
         logLevel: LogLevel.debug,
+        exception: exception,
+        error: error,
+        stackTrace: StackTrace.current,
         title: _testTitle,
+        time: dateTime,
+        pen: AnsiPen()..red(),
+        key: 'custom-key',
       );
 
       expect(log is TalkerData, true);
       expect(log is TalkerLog, true);
-      expect(log.message, _testMessage);
-      expect(log.title, _testTitle);
-      expect(log.time is DateTime, true);
+      expect(log.message, equals(_testMessage));
+      expect(log.logLevel, equals(LogLevel.debug));
+      expect(log.exception, equals(exception));
+      expect(log.error, equals(error));
+      expect(log.stackTrace is StackTrace, true);
+      expect(log.title, equals(_testTitle));
+      expect(log.time, equals(dateTime));
+      expect(log.pen, isNotNull);
+      expect(log.key, equals('custom-key'));
 
       final message = log.generateTextMessage();
       expect(
         message,
-        '''[test title] | ${TalkerDateTimeFormatter(log.time).timeAndSeconds} | test message''',
+        equals(
+          '${log.displayTitleWithTime()}${log.displayMessage}${log.displayException}${log.displayError}${log.displayStackTrace}',
+        ),
       );
     });
   });

--- a/packages/talker/test/talker_data_test.dart
+++ b/packages/talker/test/talker_data_test.dart
@@ -44,7 +44,7 @@ void main() {
       expect(
         generatedMessage,
         equals(
-          '${talkerData.displayTitleWithTime()}${talkerData.displayMessage}${talkerData.displayStackTrace}',
+          '${talkerData.displayTitleWithTime()}${talkerData.displayMessage}${talkerData.displayException}${talkerData.displayError}${talkerData.displayStackTrace}',
         ),
       );
     });


### PR DESCRIPTION
* Bugfix for missing error and exception details
	**Describe the bug**
	`TalkerData#generateTextMessage` is missing `displayException` and `displayError`, uses `message` instead of `displayMessage` which could cause "null" string in logs (intended?).
	`TalkerLog#generateTextMessage` is missing `displayError` which prevents printing errors to console log.
	
	
	**To Reproduce**
	* Add custom log with error.
	* Error is not printed.
	
	**Expected behavior**
	* Error should be included in output same as exception.

## Summary by Sourcery

Ensure that error and exception details, along with the proper displayMessage, are included in console log output generated by TalkerData and TalkerLog

Bug Fixes:
- Replace raw message with displayMessage and include missing displayException and displayError in TalkerData generateTextMessage
- Add missing displayError to TalkerLog generateTextMessage so errors are printed to console logs