### PR TITLE
perf: use initializer instead of late initialization and polymorph getters

### DIFF
--- a/packages/talker/lib/src/models/talker_data.dart
+++ b/packages/talker/lib/src/models/talker_data.dart
@@ -14,18 +14,12 @@ class TalkerData {
     DateTime? time,
     this.pen,
     this.key,
-  }) {
-    _time = time ?? DateTime.now();
-  }
-
-  late DateTime _time;
+  }) : time = time ?? DateTime.now();
 
   /// {@template talker_data_message}
   /// [String] [message] - message describes what happened
   /// {@endtemplate}
   final String? message;
-
-  final String? key;
 
   /// {@template talker_data_loglevel}
   /// [LogLevel] [logLevel] - to control logging output
@@ -42,23 +36,25 @@ class TalkerData {
   /// {@endtemplate}
   final Error? error;
 
-  /// {@template talker_data_title}
-  /// Title of Talker log
-  /// {@endtemplate}
-  String? title;
-
   /// {@template talker_data_stackTrace}
   /// StackTrace?] [stackTrace] - stackTrace if [exception] or [error] happened
   /// {@endtemplate}
   final StackTrace? stackTrace;
 
+  /// {@template talker_data_title}
+  /// Title of Talker log
+  /// {@endtemplate}
+  String? title;
+
   /// {@template talker_data_time}
   /// Internal time when the log occurred
   /// {@endtemplate}
-  DateTime get time => _time;
+  final DateTime time;
 
   /// [AnsiPen?] [pen] - sets your own log color for console
   AnsiPen? pen;
+
+  final String? key;
 
   /// {@template talker_data_generateTextMessage}
   /// Internal method that generates

--- a/packages/talker/lib/src/models/talker_error.dart
+++ b/packages/talker/lib/src/models/talker_error.dart
@@ -10,19 +10,12 @@ class TalkerError extends TalkerData {
     String? key,
     super.title,
     LogLevel? logLevel,
-  }) : super(message, error: error) {
-    _key = key ?? TalkerKey.error;
-    _logLevel = logLevel ?? LogLevel.error;
-  }
-
-  late String _key;
-  late LogLevel _logLevel;
-
-  @override
-  String get key => _key;
-
-  @override
-  LogLevel? get logLevel => _logLevel;
+  }) : super(
+          message,
+          logLevel: logLevel ?? LogLevel.error,
+          error: error,
+          key: key ?? TalkerKey.error,
+        );
 
   /// {@macro talker_data_generateTextMessage}
   @override

--- a/packages/talker/lib/src/models/talker_exception.dart
+++ b/packages/talker/lib/src/models/talker_exception.dart
@@ -1,7 +1,7 @@
 import 'package:talker/talker.dart';
 
 /// Base implementation of [TalkerData]
-/// to handle ONLY [Exceptions]s
+/// to handle ONLY [Exception]s
 class TalkerException extends TalkerData {
   TalkerException(
     Exception exception, {
@@ -10,19 +10,12 @@ class TalkerException extends TalkerData {
     String? key,
     super.title,
     LogLevel? logLevel,
-  }) : super(message, exception: exception) {
-    _key = key ?? TalkerKey.exception;
-    _logLevel = logLevel ?? LogLevel.error;
-  }
-
-  late String _key;
-  late LogLevel _logLevel;
-
-  @override
-  String get key => _key;
-
-  @override
-  LogLevel? get logLevel => _logLevel;
+  }) : super(
+          message,
+          logLevel: logLevel ?? LogLevel.error,
+          exception: exception,
+          key: key ?? TalkerKey.exception,
+        );
 
   /// {@macro talker_data_generateTextMessage}
   @override


### PR DESCRIPTION
* Performance improvement: use initializer instead of late initialization and polymorph getters

## Summary by Sourcery

Use constructor initializers and final fields to remove late initialization and polymorphic getters for improved performance.

Enhancements:
- Replace private late _time and its getter in TalkerData with a final time initialized in the constructor initializer list
- Move TalkerData key field to a final property and initialize it via the constructor initializer
- Simplify TalkerException and TalkerError constructors by passing key and logLevel directly to the TalkerData super constructor and removing custom getters and late fields