### PR TITLE
[talker_chopper_logger] Add TalkerKeys registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Follow these steps to the coolest experience in error handling
 ### Add dependency
 ```yaml
 dependencies:
-  talker: ^5.0.0-dev.10
+  talker: ^5.0.0-dev.11
 ```
 
 ### Easy to use
@@ -347,7 +347,7 @@ Talker Flutter is an extension for the Dart Talker package that adds extra funct
 ### Add dependency
 ```yaml
 dependencies:
-  talker_flutter: ^5.0.0-dev.10
+  talker_flutter: ^5.0.0-dev.11
 ```
 
 ### Setup
@@ -591,7 +591,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_dio_logger: ^5.0.0-dev.10
+  talker_dio_logger: ^5.0.0-dev.11
 ```
 
 ### Usage
@@ -692,7 +692,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_bloc_logger: ^5.0.0-dev.10
+  talker_bloc_logger: ^5.0.0-dev.11
 ```
 
 ### Usage
@@ -780,7 +780,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_riverpod_logger: ^5.0.0-dev.10
+  talker_riverpod_logger: ^5.0.0-dev.11
 ```
 
 ### Usage
@@ -907,7 +907,7 @@ This is how the logs of your http requests will look in the console
 ### Add dependency
 ```yaml
 dependencies:
-  talker_chopper_logger: ^5.0.0-dev.10
+  talker_chopper_logger: ^5.0.0-dev.11
 ```
 
 ### Usage

--- a/examples/shop_app_example/pubspec.yaml
+++ b/examples/shop_app_example/pubspec.yaml
@@ -9,9 +9,9 @@ dependencies:
   flutter:
     sdk: flutter
 
-  talker_flutter: ^5.0.0-dev.10
-  talker_dio_logger: ^5.0.0-dev.10
-  talker_bloc_logger: ^5.0.0-dev.10
+  talker_flutter: ^5.0.0-dev.11
+  talker_dio_logger: ^5.0.0-dev.11
+  talker_bloc_logger: ^5.0.0-dev.11
   
   get_it: ^7.6.7
   flutter_bloc: ^9.0.0

--- a/packages/talker/CHANGELOG.md
+++ b/packages/talker/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.0-dev.11
+- - [talker_chopper_logger] Add ``TalkerKey``s registration
+
+Thanks to [Frezyx](https://github.com/Frezyx)
+
 # 5.0.0-dev.10
 - - [talker_chopper_logger] Release logger for Chopper http clint package
 

--- a/packages/talker/pubspec.yaml
+++ b/packages/talker/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker
 description: Advanced error handler and logger package for flutter and dart. App monitoring, logs history, report sharing, custom logs, and etc.
-version: 5.0.0-dev.10
+version: 5.0.0-dev.11
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
 issue_tracker: https://github.com/Frezyx/talker/issues
@@ -16,7 +16,7 @@ environment:
   sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
-  talker_logger: ^5.0.0-dev.10
+  talker_logger: ^5.0.0-dev.11
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/talker_bloc_logger/CHANGELOG.md
+++ b/packages/talker_bloc_logger/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.0-dev.11
+- - [talker_chopper_logger] Add ``TalkerKey``s registration
+
+Thanks to [Frezyx](https://github.com/Frezyx)
+
 # 5.0.0-dev.10
 - - [talker_chopper_logger] Release logger for Chopper http clint package
 

--- a/packages/talker_bloc_logger/README.md
+++ b/packages/talker_bloc_logger/README.md
@@ -31,7 +31,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_bloc_logger: ^5.0.0-dev.10
+  talker_bloc_logger: ^5.0.0-dev.11
 ```
 
 ### Usage

--- a/packages/talker_bloc_logger/pubspec.yaml
+++ b/packages/talker_bloc_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_bloc_logger
 description: Lightweight and customizable BLoC state management library logger on talker base.
-version: 5.0.0-dev.10
+version: 5.0.0-dev.11
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
 issue_tracker: https://github.com/Frezyx/talker/issues
@@ -16,7 +16,7 @@ environment:
   sdk: '>=2.15.0 <4.0.0'
 
 dependencies:
-  talker: ^5.0.0-dev.10
+  talker: ^5.0.0-dev.11
   bloc: ^9.0.0
   meta: ^1.8.0
 

--- a/packages/talker_chopper_logger/CHANGELOG.md
+++ b/packages/talker_chopper_logger/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.0-dev.11
+- - [talker_chopper_logger] Add ``TalkerKey``s registration
+
+Thanks to [Frezyx](https://github.com/Frezyx)
+
 # 5.0.0-dev.10
 - - [talker_chopper_logger] Release logger for Chopper http clint package
 

--- a/packages/talker_chopper_logger/README.md
+++ b/packages/talker_chopper_logger/README.md
@@ -31,7 +31,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_chopper_logger: ^5.0.0-dev.10
+  talker_chopper_logger: ^5.0.0-dev.11
 ```
 
 ### Usage

--- a/packages/talker_chopper_logger/example/pubspec.yaml
+++ b/packages/talker_chopper_logger/example/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  talker_chopper_logger: ^5.0.0-dev.10
-  talker_flutter: ^5.0.0-dev.10
+  talker_chopper_logger: ^5.0.0-dev.11
+  talker_flutter: ^5.0.0-dev.11
   chopper: ^8.2.0
   json_annotation: ^4.9.0
   equatable: ^2.0.7

--- a/packages/talker_chopper_logger/lib/talker_chopper_logger_interceptor.dart
+++ b/packages/talker_chopper_logger/lib/talker_chopper_logger_interceptor.dart
@@ -20,6 +20,13 @@ class TalkerChopperLogger implements Interceptor {
     this.addonId,
   }) {
     _talker = talker ?? Talker();
+    _talker.settings.registerKeys(
+      [
+        TalkerKey.httpRequest,
+        TalkerKey.httpResponse,
+        TalkerKey.httpError,
+      ],
+    );
   }
 
   late final Talker _talker;

--- a/packages/talker_chopper_logger/pubspec.yaml
+++ b/packages/talker_chopper_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_chopper_logger
 description: A lightweight, flexible HTTP client logger for Chopper built on the Talker platform, offering advanced exception handling and logging for Dart and Flutter applications.
-version: 5.0.0-dev.10
+version: 5.0.0-dev.11
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
 issue_tracker: https://github.com/Frezyx/talker/issues
@@ -20,7 +20,7 @@ dependencies:
   equatable: ^2.0.7
   http: ^1.4.0
   meta: ^1.15.0
-  talker: ^5.0.0-dev.10
+  talker: ^5.0.0-dev.11
 
 dev_dependencies:
   http_parser: ^4.1.2

--- a/packages/talker_dio_logger/CHANGELOG.md
+++ b/packages/talker_dio_logger/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.0-dev.11
+- - [talker_chopper_logger] Add ``TalkerKey``s registration
+
+Thanks to [Frezyx](https://github.com/Frezyx)
+
 # 5.0.0-dev.10
 - - [talker_chopper_logger] Release logger for Chopper http clint package
 

--- a/packages/talker_dio_logger/README.md
+++ b/packages/talker_dio_logger/README.md
@@ -31,7 +31,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_dio_logger: ^5.0.0-dev.10
+  talker_dio_logger: ^5.0.0-dev.11
 ```
 
 ### Usage

--- a/packages/talker_dio_logger/example/pubspec.yaml
+++ b/packages/talker_dio_logger/example/pubspec.yaml
@@ -10,8 +10,8 @@ dependencies:
   flutter:
     sdk: flutter
   dio: ^5.0.0
-  talker_dio_logger: ^5.0.0-dev.10
-  talker_flutter: ^5.0.0-dev.10    
+  talker_dio_logger: ^5.0.0-dev.11
+  talker_flutter: ^5.0.0-dev.11    
 
 dev_dependencies:
   flutter_test:

--- a/packages/talker_dio_logger/pubspec.yaml
+++ b/packages/talker_dio_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_dio_logger
 description: Lightweight and customizable dio http client logger on talker base
-version: 5.0.0-dev.10
+version: 5.0.0-dev.11
 
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
@@ -18,7 +18,7 @@ environment:
 
 dependencies:
   dio: ^5.4.0
-  talker: ^5.0.0-dev.10
+  talker: ^5.0.0-dev.11
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/talker_flutter/CHANGELOG.md
+++ b/packages/talker_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.0-dev.11
+- - [talker_chopper_logger] Add ``TalkerKey``s registration
+
+Thanks to [Frezyx](https://github.com/Frezyx)
+
 # 5.0.0-dev.10
 - - [talker_chopper_logger] Release logger for Chopper http clint package
 

--- a/packages/talker_flutter/pubspec.yaml
+++ b/packages/talker_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_flutter
 description: Advanced error handler and logger package for flutter and dart. App monitoring, logs history, report sharing, custom logs, and etc.
-version: 5.0.0-dev.10
+version: 5.0.0-dev.11
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
 issue_tracker: https://github.com/Frezyx/talker/issues
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  talker: ^5.0.0-dev.10
+  talker: ^5.0.0-dev.11
   group_button: ^5.3.4
   path_provider: ^2.1.4
   share_plus: ^11.0.0

--- a/packages/talker_http_logger/CHANGELOG.md
+++ b/packages/talker_http_logger/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.0-dev.11
+- - [talker_chopper_logger] Add ``TalkerKey``s registration
+
+Thanks to [Frezyx](https://github.com/Frezyx)
+
 # 5.0.0-dev.10
 - - [talker_chopper_logger] Release logger for Chopper http clint package
 

--- a/packages/talker_http_logger/README.md
+++ b/packages/talker_http_logger/README.md
@@ -23,7 +23,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_http_logger: ^5.0.0-dev.10
+  talker_http_logger: ^5.0.0-dev.11
 ```
 
 ### Usage

--- a/packages/talker_http_logger/pubspec.yaml
+++ b/packages/talker_http_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_http_logger
 description: Lightweight and customizable http client logger on talker base
-version: 5.0.0-dev.10
+version: 5.0.0-dev.11
 homepage: https://github.com/Frezyx/talker
 
 environment:
@@ -9,7 +9,7 @@ environment:
 dependencies:
   equatable: ^2.0.7
   http_interceptor: ^2.0.0
-  talker: ^5.0.0-dev.10
+  talker: ^5.0.0-dev.11
   meta: ^1.15.0
 
 dev_dependencies:

--- a/packages/talker_logger/CHANGELOG.md
+++ b/packages/talker_logger/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.0-dev.11
+- - [talker_chopper_logger] Add ``TalkerKey``s registration
+
+Thanks to [Frezyx](https://github.com/Frezyx)
+
 # 5.0.0-dev.10
 - - [talker_chopper_logger] Release logger for Chopper http clint package
 

--- a/packages/talker_logger/README.md
+++ b/packages/talker_logger/README.md
@@ -23,7 +23,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_logger: ^5.0.0-dev.10
+  talker_logger: ^5.0.0-dev.11
 ```
 
 ### Easy to use

--- a/packages/talker_logger/pubspec.yaml
+++ b/packages/talker_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_logger
 description: Logger. Easy, customizable, extensible logging, lightweight with filters, formatters, custom logs, log levels.
-version: 5.0.0-dev.10
+version: 5.0.0-dev.11
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
 issue_tracker: https://github.com/Frezyx/talker/issues

--- a/packages/talker_riverpod_logger/CHANGELOG.md
+++ b/packages/talker_riverpod_logger/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 5.0.0-dev.11
+- - [talker_chopper_logger] Add ``TalkerKey``s registration
+
+Thanks to [Frezyx](https://github.com/Frezyx)
+
 # 5.0.0-dev.10
 - - [talker_chopper_logger] Release logger for Chopper http clint package
 

--- a/packages/talker_riverpod_logger/README.md
+++ b/packages/talker_riverpod_logger/README.md
@@ -31,7 +31,7 @@ Follow these steps to use this package
 ### Add dependency
 ```yaml
 dependencies:
-  talker_riverpod_logger: ^5.0.0-dev.10
+  talker_riverpod_logger: ^5.0.0-dev.11
 ```
 
 ### Usage

--- a/packages/talker_riverpod_logger/example/pubspec.yaml
+++ b/packages/talker_riverpod_logger/example/pubspec.yaml
@@ -8,9 +8,9 @@ dependencies:
   crypto: ^3.0.0
   dio: ^5.1.1
   freezed_annotation: ^3.0.0
-  json_annotation: ^5.0.0-dev.10
+  json_annotation: ^5.0.0-dev.11
   riverpod: ^2.5.0
-  talker_riverpod_logger: ^5.0.0-dev.10
+  talker_riverpod_logger: ^5.0.0-dev.11
 
 dev_dependencies:
   build_runner: ^2.0.0

--- a/packages/talker_riverpod_logger/pubspec.yaml
+++ b/packages/talker_riverpod_logger/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talker_riverpod_logger
 description: Lightweight and customizable Riverpod state management library logger on talker base.
-version: 5.0.0-dev.10
+version: 5.0.0-dev.11
 homepage: https://github.com/Frezyx/talker
 repository: https://github.com/Frezyx/talker
 issue_tracker: https://github.com/Frezyx/talker/issues
@@ -15,7 +15,7 @@ environment:
   sdk: ">=2.15.0 <4.0.0"
 
 dependencies:
-  talker: ^5.0.0-dev.10
+  talker: ^5.0.0-dev.11
   riverpod: ^2.5.0
   meta: ^1.8.0
 

--- a/utils/version.txt
+++ b/utils/version.txt
@@ -1,4 +1,4 @@
-5.0.0-dev.9
 5.0.0-dev.10
-- [talker_chopper_logger] Release logger for Chopper http clint package
-techouse
+5.0.0-dev.11
+- [talker_chopper_logger] Add ``TalkerKey``s registration
+Frezyx


### PR DESCRIPTION
## Summary by Sourcery

Bump the project to 5.0.0-dev.11, sync dependency versions across packages, examples, and documentation, and add HTTP TalkerKeys registration in the Chopper logger interceptor

New Features:
- Register HTTP-related TalkerKeys (httpRequest, httpResponse, httpError) in the Chopper logger interceptor

Enhancements:
- Bump all package versions to 5.0.0-dev.11 and update corresponding dependencies
- Synchronize example and README dependency versions to the new dev.11 release

Documentation:
- Update READMEs with revised dependency versions for the 5.0.0-dev.11 release

Chores:
- Refresh CHANGELOG entries for version 5.0.0-dev.11 across all packages