### PR TITLE
Add log timestamp option to Dio logger settings

### DIFF
--- a/packages/talker_dio_logger/lib/dio_logs.dart
+++ b/packages/talker_dio_logger/lib/dio_logs.dart
@@ -32,6 +32,11 @@ class DioRequestLog extends TalkerLog {
   }) {
     var msg = '[$title] [${requestOptions.method}] $message';
 
+    if (settings.logTimestamp) {
+      msg +=
+          '\n Date: ${displayTime(timeFormat: TimeFormat.yearMonthDayAndTime)}';
+    }
+
     final data = requestOptions.data;
     final headers = Map.from(requestOptions.headers);
 
@@ -119,6 +124,11 @@ class DioResponseLog extends TalkerLog {
   }) {
     var msg = '[$title] [${response.requestOptions.method}] $message';
 
+    if (settings.logTimestamp) {
+      msg +=
+          '\n Date: ${displayTime(timeFormat: TimeFormat.yearMonthDayAndTime)}';
+    }
+
     final responseMessage = response.statusMessage;
     final data = response.data;
     final headers = response.headers.map;
@@ -186,6 +196,11 @@ class DioErrorLog extends TalkerLog {
     TimeFormat timeFormat = TimeFormat.timeAndSeconds,
   }) {
     var msg = '[$title] [${dioException.requestOptions.method}] $message';
+
+    if (settings.logTimestamp) {
+      msg +=
+          '\n Date: ${displayTime(timeFormat: TimeFormat.yearMonthDayAndTime)}';
+    }
 
     final responseMessage = dioException.message;
     final statusCode = dioException.response?.statusCode;

--- a/packages/talker_dio_logger/lib/dio_logs.dart
+++ b/packages/talker_dio_logger/lib/dio_logs.dart
@@ -7,6 +7,24 @@ import 'package:talker_dio_logger/talker_dio_logger.dart';
 const _encoder = JsonEncoder.withIndent('  ');
 const _hiddenValue = '*****';
 
+/// Shared helper that appends a formatted timestamp line to [msg] when
+/// [settings.logTimestamp] is enabled.
+///
+/// Uses the customisable [TalkerDioLoggerSettings.timestampLabel] and
+/// [TalkerDioLoggerSettings.timestampFormat] so the format and label are
+/// consistent across request, response, and error logs.
+String _appendTimestamp(
+  String msg,
+  TalkerDioLoggerSettings settings,
+  String Function({required TimeFormat timeFormat}) displayTime,
+) {
+  if (settings.logTimestamp) {
+    msg +=
+        '\n ${settings.timestampLabel}: ${displayTime(timeFormat: settings.timestampFormat)}';
+  }
+  return msg;
+}
+
 class DioRequestLog extends TalkerLog {
   DioRequestLog(
     String message, {
@@ -31,11 +49,7 @@ class DioRequestLog extends TalkerLog {
     TimeFormat timeFormat = TimeFormat.timeAndSeconds,
   }) {
     var msg = '[$title] [${requestOptions.method}] $message';
-
-    if (settings.logTimestamp) {
-      msg +=
-          '\n Date: ${displayTime(timeFormat: TimeFormat.yearMonthDayAndTime)}';
-    }
+    msg = _appendTimestamp(msg, settings, displayTime);
 
     final data = requestOptions.data;
     final headers = Map.from(requestOptions.headers);
@@ -123,11 +137,7 @@ class DioResponseLog extends TalkerLog {
     TimeFormat timeFormat = TimeFormat.timeAndSeconds,
   }) {
     var msg = '[$title] [${response.requestOptions.method}] $message';
-
-    if (settings.logTimestamp) {
-      msg +=
-          '\n Date: ${displayTime(timeFormat: TimeFormat.yearMonthDayAndTime)}';
-    }
+    msg = _appendTimestamp(msg, settings, displayTime);
 
     final responseMessage = response.statusMessage;
     final data = response.data;
@@ -196,11 +206,7 @@ class DioErrorLog extends TalkerLog {
     TimeFormat timeFormat = TimeFormat.timeAndSeconds,
   }) {
     var msg = '[$title] [${dioException.requestOptions.method}] $message';
-
-    if (settings.logTimestamp) {
-      msg +=
-          '\n Date: ${displayTime(timeFormat: TimeFormat.yearMonthDayAndTime)}';
-    }
+    msg = _appendTimestamp(msg, settings, displayTime);
 
     final responseMessage = dioException.message;
     final statusCode = dioException.response?.statusCode;

--- a/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
+++ b/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
@@ -17,6 +17,7 @@ class TalkerDioLoggerSettings {
     this.printRequestData = true,
     this.printRequestHeaders = false,
     this.printRequestExtra = false,
+    this.logTimestamp = false,
     this.hiddenHeaders = const <String>{},
     this.responseDataConverter,
     this.requestPen,
@@ -65,6 +66,9 @@ class TalkerDioLoggerSettings {
 
   /// Print [request.extra] if true
   final bool printRequestExtra;
+
+  /// Print timestamp in logs if true
+  final bool logTimestamp;
 
   /// Field to set custom http request console logs color
   ///```
@@ -129,6 +133,7 @@ class TalkerDioLoggerSettings {
     bool? printRequestData,
     bool? printRequestHeaders,
     bool? printRequestExtra,
+    bool? logTimestamp,
     AnsiPen? requestPen,
     AnsiPen? responsePen,
     AnsiPen? errorPen,
@@ -150,6 +155,7 @@ class TalkerDioLoggerSettings {
       printRequestData: printRequestData ?? this.printRequestData,
       printRequestHeaders: printRequestHeaders ?? this.printRequestHeaders,
       printRequestExtra: printRequestExtra ?? this.printRequestExtra,
+      logTimestamp: logTimestamp ?? this.logTimestamp,
       requestPen: requestPen ?? this.requestPen,
       responsePen: responsePen ?? this.responsePen,
       errorPen: errorPen ?? this.errorPen,

--- a/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
+++ b/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
@@ -18,6 +18,8 @@ class TalkerDioLoggerSettings {
     this.printRequestHeaders = false,
     this.printRequestExtra = false,
     this.logTimestamp = false,
+    this.timestampFormat = TimeFormat.yearMonthDayAndTime,
+    this.timestampLabel = 'Date',
     this.hiddenHeaders = const <String>{},
     this.responseDataConverter,
     this.requestPen,
@@ -69,6 +71,14 @@ class TalkerDioLoggerSettings {
 
   /// Print timestamp in logs if true
   final bool logTimestamp;
+
+  /// The [TimeFormat] used when [logTimestamp] is enabled.
+  /// Defaults to [TimeFormat.yearMonthDayAndTime].
+  final TimeFormat timestampFormat;
+
+  /// The label printed before the timestamp value when [logTimestamp] is enabled.
+  /// Defaults to `'Date'`.
+  final String timestampLabel;
 
   /// Field to set custom http request console logs color
   ///```
@@ -134,6 +144,8 @@ class TalkerDioLoggerSettings {
     bool? printRequestHeaders,
     bool? printRequestExtra,
     bool? logTimestamp,
+    TimeFormat? timestampFormat,
+    String? timestampLabel,
     AnsiPen? requestPen,
     AnsiPen? responsePen,
     AnsiPen? errorPen,
@@ -156,6 +168,8 @@ class TalkerDioLoggerSettings {
       printRequestHeaders: printRequestHeaders ?? this.printRequestHeaders,
       printRequestExtra: printRequestExtra ?? this.printRequestExtra,
       logTimestamp: logTimestamp ?? this.logTimestamp,
+      timestampFormat: timestampFormat ?? this.timestampFormat,
+      timestampLabel: timestampLabel ?? this.timestampLabel,
       requestPen: requestPen ?? this.requestPen,
       responsePen: responsePen ?? this.responsePen,
       errorPen: errorPen ?? this.errorPen,


### PR DESCRIPTION
- Introduced `logTimestamp` setting in `TalkerDioLoggerSettings` to control timestamp logging.
- Updated `DioRequestLog`, `DioResponseLog`, and `DioErrorLog` to include timestamp in log messages when `logTimestamp` is enabled.

### Thanks a lot for contributing!<br>
Provide a description of your changes below
https://github.com/Frezyx/talker/issues/412

## Summary by Sourcery

New Features:
- Add `logTimestamp` option to TalkerDioLoggerSettings to toggle timestamp inclusion in logs