### PR TITLE
Fix talker.handle docs to use stack trace before error message

### DIFF
--- a/packages/talker/lib/src/talker.dart
+++ b/packages/talker/lib/src/talker.dart
@@ -160,14 +160,14 @@ class Talker {
 
   /// Handle common exceptions in your code
   /// [Object] [exception] - exception
-  /// [String?] [msg] - message describes what happened
   /// [StackTrace?] [stackTrace] - stackTrace
+  /// [String?] [msg] - message describes what happened
   ///
   /// ```dart
   /// try {
   ///   // your code...
   /// } catch (e, st) {
-  ///   talker.handle(e, 'Exception in ...', st);
+  ///   talker.handle(e, st, 'Exception in ...');
   /// }
   /// ```
   ///


### PR DESCRIPTION
The code docs for `talker.handle` incorrectly show the error message argument before the stack trace. This PR fixes that.

## Summary by Sourcery

Fix parameter order in talker.handle documentation to place the stack trace argument before the error message

Documentation:
- Update talker.handle doc comments to swap the order of the stackTrace and msg parameters
- Correct the code example to call talker.handle(e, st, 'Exception in ...') instead of talker.handle(e, 'Exception in ...', st)