### PR TITLE
riverpod 3.0.0 support

### DIFF
--- a/packages/talker_flutter/example/linux/flutter/ephemeral/.plugin_symlinks/path_provider_linux
+++ b/packages/talker_flutter/example/linux/flutter/ephemeral/.plugin_symlinks/path_provider_linux
@@ -1,1 +1,1 @@
-/Users/stanislavilin/.pub-cache/hosted/pub.dev/path_provider_linux-2.2.1/
+/Users/venir/.pub-cache/hosted/pub.dev/path_provider_linux-2.2.1/

--- a/packages/talker_flutter/example/linux/flutter/ephemeral/.plugin_symlinks/share_plus
+++ b/packages/talker_flutter/example/linux/flutter/ephemeral/.plugin_symlinks/share_plus
@@ -1,1 +1,1 @@
-/Users/stanislavilin/.pub-cache/hosted/pub.dev/share_plus-11.1.0/
+/Users/venir/.pub-cache/hosted/pub.dev/share_plus-11.1.0/

--- a/packages/talker_flutter/example/linux/flutter/ephemeral/.plugin_symlinks/url_launcher_linux
+++ b/packages/talker_flutter/example/linux/flutter/ephemeral/.plugin_symlinks/url_launcher_linux
@@ -1,1 +1,1 @@
-/Users/stanislavilin/.pub-cache/hosted/pub.dev/url_launcher_linux-3.2.1/
+/Users/venir/.pub-cache/hosted/pub.dev/url_launcher_linux-3.2.1/

--- a/packages/talker_riverpod_logger/example/pubspec.yaml
+++ b/packages/talker_riverpod_logger/example/pubspec.yaml
@@ -5,15 +5,15 @@ environment:
   sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
-  crypto: ^3.0.0
-  dio: ^5.1.1
-  freezed_annotation: ^3.0.0
+  crypto: ^3.0.6
+  dio: ^5.9.0
+  freezed_annotation: ^3.1.0
   json_annotation: ^4.9.0
-  riverpod: ^2.5.0
+  riverpod: ^3.0.0
   talker_riverpod_logger: ^5.0.0
 
 dev_dependencies:
-  build_runner: ^2.0.0
-  freezed: ^3.0.0
-  json_serializable: ^6.3.0
-  test: ^1.16.0
+  build_runner: ^2.8.0
+  freezed: ^3.2.3
+  json_serializable: ^6.11.1
+  test: ^1.26.3

--- a/packages/talker_riverpod_logger/example/pubspec.yaml
+++ b/packages/talker_riverpod_logger/example/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   crypto: ^3.0.0
   dio: ^5.1.1
   freezed_annotation: ^3.0.0
-  json_annotation: ^5.0.0
+  json_annotation: ^4.9.0
   riverpod: ^2.5.0
   talker_riverpod_logger: ^5.0.0
 

--- a/packages/talker_riverpod_logger/lib/riverpod_logs.dart
+++ b/packages/talker_riverpod_logger/lib/riverpod_logs.dart
@@ -1,4 +1,4 @@
-import 'package:riverpod/riverpod.dart';
+import 'package:riverpod/misc.dart';
 import 'package:talker/talker.dart';
 import 'package:talker_riverpod_logger/talker_riverpod_logger.dart';
 
@@ -15,12 +15,7 @@ class RiverpodAddLog extends TalkerLog {
     required this.provider,
     required this.value,
     required this.settings,
-  }) : super(
-          _defaultMessage(
-            provider: provider,
-            suffix: 'initialized',
-          ),
-        );
+  }) : super(_defaultMessage(provider: provider, suffix: 'initialized'));
 
   final ProviderBase<Object?> provider;
   final Object? value;
@@ -37,7 +32,8 @@ class RiverpodAddLog extends TalkerLog {
     sb.write(displayTitleWithTime(timeFormat: timeFormat));
     sb.write('\n$message');
     sb.write(
-        '\n${'INITIAL state: ${settings.printStateFullData ? '\n$value' : value.runtimeType}'}');
+      '\n${'INITIAL state: ${settings.printStateFullData ? '\n$value' : value.runtimeType}'}',
+    );
     return sb.toString();
   }
 }
@@ -49,12 +45,7 @@ class RiverpodUpdateLog extends TalkerLog {
     required this.previousValue,
     required this.newValue,
     required this.settings,
-  }) : super(
-          _defaultMessage(
-            provider: provider,
-            suffix: 'updated',
-          ),
-        );
+  }) : super(_defaultMessage(provider: provider, suffix: 'updated'));
 
   final ProviderBase<Object?> provider;
   final Object? previousValue;
@@ -72,24 +63,19 @@ class RiverpodUpdateLog extends TalkerLog {
     sb.write(displayTitleWithTime(timeFormat: timeFormat));
     sb.write('\n$message');
     sb.write(
-        '\n${'PREVIOUS state: ${settings.printStateFullData ? '\n$previousValue' : previousValue.runtimeType}'}');
+      '\n${'PREVIOUS state: ${settings.printStateFullData ? '\n$previousValue' : previousValue.runtimeType}'}',
+    );
     sb.write(
-        '\n${'NEW state: ${settings.printStateFullData ? '\n$newValue' : newValue.runtimeType}'}');
+      '\n${'NEW state: ${settings.printStateFullData ? '\n$newValue' : newValue.runtimeType}'}',
+    );
     return sb.toString();
   }
 }
 
 /// [Riverpod] dispose provider log model
 class RiverpodDisposeLog extends TalkerLog {
-  RiverpodDisposeLog({
-    required this.provider,
-    required this.settings,
-  }) : super(
-          _defaultMessage(
-            provider: provider,
-            suffix: 'disposed',
-          ),
-        );
+  RiverpodDisposeLog({required this.provider, required this.settings})
+    : super(_defaultMessage(provider: provider, suffix: 'disposed'));
 
   final ProviderBase<Object?> provider;
   final TalkerRiverpodLoggerSettings settings;
@@ -115,12 +101,7 @@ class RiverpodFailLog extends TalkerLog {
     required this.providerError,
     required this.providerStackTrace,
     required this.settings,
-  }) : super(
-          _defaultMessage(
-            provider: provider,
-            suffix: 'failed',
-          ),
-        );
+  }) : super(_defaultMessage(provider: provider, suffix: 'failed'));
 
   final ProviderBase<Object?> provider;
   final Object providerError;

--- a/packages/talker_riverpod_logger/lib/talker_riverpod_logger_observer.dart
+++ b/packages/talker_riverpod_logger/lib/talker_riverpod_logger_observer.dart
@@ -8,20 +8,18 @@ import 'package:talker_riverpod_logger/talker_riverpod_logger.dart';
 /// [talker] field is the current [Talker] instance.
 /// Provide your instance if your application uses [Talker] as the default logger
 /// Common Talker instance will be used by default
-class TalkerRiverpodObserver extends ProviderObserver {
+base class TalkerRiverpodObserver extends ProviderObserver {
   TalkerRiverpodObserver({
     Talker? talker,
     this.settings = const TalkerRiverpodLoggerSettings(),
   }) {
     _talker = talker ?? Talker();
-    _talker.settings.registerKeys(
-      [
-        TalkerKey.riverpodAdd,
-        TalkerKey.riverpodUpdate,
-        TalkerKey.riverpodDispose,
-        TalkerKey.riverpodFail,
-      ],
-    );
+    _talker.settings.registerKeys([
+      TalkerKey.riverpodAdd,
+      TalkerKey.riverpodUpdate,
+      TalkerKey.riverpodDispose,
+      TalkerKey.riverpodFail,
+    ]);
   }
 
   late Talker _talker;
@@ -29,22 +27,17 @@ class TalkerRiverpodObserver extends ProviderObserver {
 
   @override
   @mustCallSuper
-  void didAddProvider(
-    ProviderBase<Object?> provider,
-    Object? value,
-    ProviderContainer container,
-  ) {
-    super.didAddProvider(provider, value, container);
-    if (!settings.enabled || !settings.printProviderAdded) {
-      return;
-    }
-    final accepted = settings.providerFilter?.call(provider) ?? true;
-    if (!accepted) {
-      return;
-    }
+  void didAddProvider(ProviderObserverContext context, Object? value) {
+    super.didAddProvider(context, value);
+
+    if (!settings.enabled || !settings.printProviderAdded) return;
+
+    final accepted = settings.providerFilter?.call(context.provider) ?? true;
+    if (!accepted) return;
+
     _talker.logCustom(
       RiverpodAddLog(
-        provider: provider,
+        provider: context.provider,
         value: value,
         settings: settings,
       ),
@@ -54,22 +47,20 @@ class TalkerRiverpodObserver extends ProviderObserver {
   @override
   @mustCallSuper
   void didUpdateProvider(
-    ProviderBase<Object?> provider,
+    ProviderObserverContext context,
     Object? previousValue,
     Object? newValue,
-    ProviderContainer container,
   ) {
-    super.didUpdateProvider(provider, previousValue, newValue, container);
-    if (!settings.enabled || !settings.printProviderUpdated) {
-      return;
-    }
-    final accepted = settings.providerFilter?.call(provider) ?? true;
-    if (!accepted) {
-      return;
-    }
+    super.didUpdateProvider(context, previousValue, newValue);
+
+    if (!settings.enabled || !settings.printProviderUpdated) return;
+
+    final accepted = settings.providerFilter?.call(context.provider) ?? true;
+    if (!accepted) return;
+
     _talker.logCustom(
       RiverpodUpdateLog(
-        provider: provider,
+        provider: context.provider,
         previousValue: previousValue,
         newValue: newValue,
         settings: settings,
@@ -79,55 +70,40 @@ class TalkerRiverpodObserver extends ProviderObserver {
 
   @override
   @mustCallSuper
-  void didDisposeProvider(
-    ProviderBase<Object?> provider,
-    ProviderContainer container,
-  ) {
-    super.didDisposeProvider(provider, container);
-    if (!settings.enabled || !settings.printProviderDisposed) {
-      return;
-    }
-    final accepted = settings.providerFilter?.call(provider) ?? true;
-    if (!accepted) {
-      return;
-    }
+  void didDisposeProvider(ProviderObserverContext context) {
+    super.didDisposeProvider(context);
+    if (!settings.enabled || !settings.printProviderDisposed) return;
+
+    final accepted = settings.providerFilter?.call(context.provider) ?? true;
+    if (!accepted) return;
+
     _talker.logCustom(
-      RiverpodDisposeLog(
-        provider: provider,
-        settings: settings,
-      ),
+      RiverpodDisposeLog(provider: context.provider, settings: settings),
     );
   }
 
   @override
   @mustCallSuper
   void providerDidFail(
-    ProviderBase<Object?> provider,
+    ProviderObserverContext context,
     Object error,
     StackTrace stackTrace,
-    ProviderContainer container,
   ) {
-    super.providerDidFail(provider, error, stackTrace, container);
-    if (!settings.enabled || !settings.printProviderFailed) {
-      return;
-    }
-    final accepted = settings.providerFilter?.call(provider) ?? true;
-    if (!accepted) {
-      return;
-    }
+    super.providerDidFail(context, error, stackTrace);
+    if (!settings.enabled || !settings.printProviderFailed) return;
+    final accepted = settings.providerFilter?.call(context.provider) ?? true;
+    if (!accepted) return;
 
     try {
-      final errorFiltered = settings.didFailFilter?.call(error) ?? true;
-      if (!errorFiltered) {
-        return;
-      }
+      final filtered = settings.didFailFilter?.call(error) ?? true;
+      if (!filtered) return;
     } catch (_) {
       return;
     }
 
     _talker.logCustom(
       RiverpodFailLog(
-        provider: provider,
+        provider: context.provider,
         providerError: error,
         providerStackTrace: stackTrace,
         settings: settings,

--- a/packages/talker_riverpod_logger/lib/talker_riverpod_logger_settings.dart
+++ b/packages/talker_riverpod_logger/lib/talker_riverpod_logger_settings.dart
@@ -1,4 +1,4 @@
-import 'package:riverpod/riverpod.dart';
+import 'package:riverpod/misc.dart';
 
 class TalkerRiverpodLoggerSettings {
   const TalkerRiverpodLoggerSettings({

--- a/packages/talker_riverpod_logger/pubspec.yaml
+++ b/packages/talker_riverpod_logger/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 dependencies:
   talker: ^5.0.0
   riverpod: ^3.0.0
-  meta: ^1.17.0
+  meta: ^1.16.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/talker_riverpod_logger/pubspec.yaml
+++ b/packages/talker_riverpod_logger/pubspec.yaml
@@ -12,13 +12,13 @@ topics:
   - log
 
 environment:
-  sdk: ">=2.15.0 <4.0.0"
+  sdk: ">=3.9.0 <4.0.0"
 
 dependencies:
   talker: ^5.0.0
-  riverpod: ^2.5.0
-  meta: ^1.8.0
+  riverpod: ^3.0.0
+  meta: ^1.17.0
 
 dev_dependencies:
-  lints: ^5.0.0
-  test: ^1.23.1
+  lints: ^6.0.0
+  test: ^1.26.3

--- a/packages/talker_riverpod_logger/pubspec.yaml
+++ b/packages/talker_riverpod_logger/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 dependencies:
   talker: ^5.0.0
   riverpod: ^3.0.0
-  meta: ^1.16.0
+  meta: ^1.15.0
 
 dev_dependencies:
   lints: ^6.0.0

--- a/packages/talker_riverpod_logger/test/logs_test.dart
+++ b/packages/talker_riverpod_logger/test/logs_test.dart
@@ -1,4 +1,4 @@
-import 'package:riverpod/riverpod.dart';
+import 'package:riverpod/legacy.dart';
 import 'package:talker/talker.dart';
 import 'package:talker_riverpod_logger/talker_riverpod_logger.dart';
 import 'package:test/test.dart';
@@ -30,10 +30,7 @@ void main() {
 
   group('RiverpodAddLog with name', () {
     test('Constructor should set values correctly', () {
-      final fakeProvider = StateProvider(
-        (ref) => 0,
-        name: 'fakeProvider',
-      );
+      final fakeProvider = StateProvider((ref) => 0, name: 'fakeProvider');
       final fakeValue = Object();
       final fakeSettings = TalkerRiverpodLoggerSettings();
 
@@ -85,10 +82,7 @@ void main() {
 
   group('RiverpodUpdateLog with name', () {
     test('Constructor should set values correctly', () {
-      final fakeProvider = StateProvider(
-        (ref) => 0,
-        name: 'fakeProvider',
-      );
+      final fakeProvider = StateProvider((ref) => 0, name: 'fakeProvider');
       final fakePreviousValue = Object();
       final fakeNewValue = Object();
       final fakeSettings = TalkerRiverpodLoggerSettings();
@@ -137,10 +131,7 @@ void main() {
 
   group('RiverpodDisposeLog with name', () {
     test('Constructor should set values correctly', () {
-      final fakeProvider = StateProvider(
-        (ref) => 0,
-        name: 'fakeProvider',
-      );
+      final fakeProvider = StateProvider((ref) => 0, name: 'fakeProvider');
       final fakeSettings = TalkerRiverpodLoggerSettings();
 
       final log = RiverpodDisposeLog(
@@ -188,10 +179,7 @@ void main() {
 
   group('RiverpodFailLog with name', () {
     test('Constructor should set values correctly', () {
-      final fakeProvider = StateProvider(
-        (ref) => 0,
-        name: 'fakeProvider',
-      );
+      final fakeProvider = StateProvider((ref) => 0, name: 'fakeProvider');
       final fakeError = Object();
       final fakeStackTrace = StackTrace.empty;
       final fakeSettings = TalkerRiverpodLoggerSettings();


### PR DESCRIPTION
riverpod 3.0 is out!

this fixes #424

## Summary by Sourcery

Migrate the package to Riverpod 3.0 by updating observer interfaces, provider APIs, imports, and test code, and bump dependency constraints accordingly.

New Features:
- Adopt Riverpod 3 provider observer signatures with ProviderObserverContext
- Switch to NotifierProvider.autoDispose and ProviderContainer.test from Riverpod 3 APIs

Enhancements:
- Update pubspecs to require Riverpod 3.0 and new SDK, dependency, and lint versions
- Simplify log class constructors and adjust import paths to riverpod/misc.dart and riverpod/legacy.dart

Tests:
- Refactor tests to use Riverpod 3’s new provider types, listening patterns, and autoDispose behavior