### PR TITLE
bump share_plus dependency to version 12.0.1

### DIFF
--- a/packages/talker_flutter/pubspec.yaml
+++ b/packages/talker_flutter/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   talker: ^5.1.0
   group_button: ^5.3.4
   path_provider: ^2.1.4
-  share_plus: ^12.0.0
+  share_plus: ^12.0.1
   web: ^1.1.0
 
 


### PR DESCRIPTION
This pull request updates the share_plus package to the latest available version. The update resolves the issue where the Share button does not work on iOS.

Related Issue
Fixes #440

Changes
Updated share_plus to the latest version in pubspec.yaml

Notes
The iOS share functionality was affected by a known bug in older versions of share_plus. Updating the package resolves the problem.

## Summary by Sourcery

Update the talker_flutter package to use the latest patch version of the share_plus dependency.

Bug Fixes:
- Resolve an iOS issue where the Share button could fail due to a bug in the previous share_plus version.

Build:
- Bump the share_plus dependency from 12.0.0 to 12.0.1 in pubspec.yaml.