### PR TITLE
Add custom pretty formatter and strip quotes option

### DIFF
--- a/packages/talker/lib/src/utils/json_formatter.dart
+++ b/packages/talker/lib/src/utils/json_formatter.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+const _defaultEncoder = JsonEncoder.withIndent('  ');
+
+/// Formatter for converting data to pretty JSON strings.
+///
+/// Use `const TalkerJsonFormatter()` for standard JSON formatting,
+/// `TalkerJsonFormatter(stripQuotes: true)` to strip quotes,
+/// or `TalkerJsonFormatter.custom(fn)` for custom formatting.
+class TalkerJsonFormatter {
+  /// Creates a formatter with optional quote stripping.
+  ///
+  /// If [stripQuotes] is true, double quotes will be stripped from
+  /// the JSON output (except escaped quotes within values).
+  const TalkerJsonFormatter({this.stripQuotes = false})
+      : _customFormatter = null;
+
+  /// Creates a formatter with a custom formatting function.
+  const TalkerJsonFormatter.custom(this._customFormatter) : stripQuotes = false;
+
+  /// Whether to strip double quotes from JSON output.
+  final bool stripQuotes;
+
+  final String Function(dynamic data)? _customFormatter;
+
+  /// Formats the given data to a pretty JSON string.
+  String format(dynamic data) {
+    if (_customFormatter != null) {
+      return _customFormatter!(data);
+    }
+    final json = _defaultEncoder.convert(data);
+    if (stripQuotes) {
+      return json
+          .replaceAll(r'\"', '\x00')
+          .replaceAll('"', '')
+          .replaceAll('\x00', '"');
+    }
+    return json;
+  }
+}

--- a/packages/talker/lib/src/utils/utils.dart
+++ b/packages/talker/lib/src/utils/utils.dart
@@ -1,3 +1,4 @@
 export 'error_handler.dart';
+export 'json_formatter.dart';
 export 'time_formatter.dart';
 export 'time_format.dart';

--- a/packages/talker/test/json_formatter_test.dart
+++ b/packages/talker/test/json_formatter_test.dart
@@ -1,0 +1,141 @@
+import 'package:talker/talker.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TalkerJsonFormatter', () {
+    group('default formatter', () {
+      test('formats simple object with indentation', () {
+        const formatter = TalkerJsonFormatter();
+        final result = formatter.format({'name': 'John', 'age': 30});
+
+        expect(result, contains('"name": "John"'));
+        expect(result, contains('"age": 30'));
+        expect(result, contains('\n')); // Has indentation
+      });
+
+      test('formats nested object', () {
+        const formatter = TalkerJsonFormatter();
+        final result = formatter.format({
+          'user': {'name': 'John', 'age': 30}
+        });
+
+        expect(result, contains('"user"'));
+        expect(result, contains('"name": "John"'));
+      });
+
+      test('formats list', () {
+        const formatter = TalkerJsonFormatter();
+        final result = formatter.format([1, 2, 3]);
+
+        expect(result, contains('1'));
+        expect(result, contains('2'));
+        expect(result, contains('3'));
+      });
+    });
+
+    group('stripQuotes', () {
+      test('strips quotes from keys and string values', () {
+        const formatter = TalkerJsonFormatter(stripQuotes: true);
+        final result = formatter.format({'name': 'John', 'age': 30});
+
+        expect(result, contains('name: John'));
+        expect(result, contains('age: 30'));
+        expect(result, isNot(contains('"name"')));
+        expect(result, isNot(contains('"John"')));
+      });
+
+      test('preserves escaped quotes in values', () {
+        const formatter = TalkerJsonFormatter(stripQuotes: true);
+        final result = formatter.format({'name': 'John "Doe"'});
+
+        expect(result, contains('name: John "Doe"'));
+      });
+
+      test('handles nested objects with escaped quotes', () {
+        const formatter = TalkerJsonFormatter(stripQuotes: true);
+        final result = formatter.format({
+          'user': {'name': 'John "The Man" Doe', 'title': 'Mr.'}
+        });
+
+        expect(result, contains('name: John "The Man" Doe'));
+        expect(result, contains('title: Mr.'));
+      });
+
+      test('strips quotes from array elements', () {
+        const formatter = TalkerJsonFormatter(stripQuotes: true);
+        final result = formatter.format(['hello', 'world']);
+
+        expect(result, isNot(contains('"hello"')));
+        expect(result, isNot(contains('"world"')));
+      });
+    });
+
+    group('custom formatter', () {
+      test('uses custom formatter function', () {
+        final formatter = TalkerJsonFormatter.custom((data) => 'CUSTOM: $data');
+        final result = formatter.format({'key': 'value'});
+
+        expect(result, equals('CUSTOM: {key: value}'));
+      });
+
+      test('custom formatter receives original data', () {
+        dynamic receivedData;
+        final formatter = TalkerJsonFormatter.custom((data) {
+          receivedData = data;
+          return 'processed';
+        });
+
+        final inputData = {'key': 'value'};
+        formatter.format(inputData);
+
+        expect(receivedData, equals(inputData));
+      });
+
+      test('custom formatter ignores stripQuotes', () {
+        // stripQuotes is set to false when using custom constructor
+        final formatter = TalkerJsonFormatter.custom((data) => 'CUSTOM: $data');
+
+        expect(formatter.stripQuotes, isFalse);
+      });
+    });
+
+    group('edge cases', () {
+      test('handles null value in map', () {
+        const formatter = TalkerJsonFormatter();
+        final result = formatter.format({'key': null});
+
+        expect(result, contains('null'));
+      });
+
+      test('handles empty map', () {
+        const formatter = TalkerJsonFormatter();
+        final result = formatter.format({});
+
+        expect(result, equals('{}'));
+      });
+
+      test('handles empty list', () {
+        const formatter = TalkerJsonFormatter();
+        final result = formatter.format([]);
+
+        expect(result, equals('[]'));
+      });
+
+      test('handles boolean values', () {
+        const formatter = TalkerJsonFormatter(stripQuotes: true);
+        final result = formatter.format({'active': true, 'deleted': false});
+
+        expect(result, contains('active: true'));
+        expect(result, contains('deleted: false'));
+      });
+
+      test('handles numeric values', () {
+        const formatter = TalkerJsonFormatter(stripQuotes: true);
+        final result = formatter.format({'int': 42, 'double': 3.14});
+
+        expect(result, contains('int: 42'));
+        expect(result, contains('double: 3.14'));
+      });
+    });
+  });
+}

--- a/packages/talker_chopper_logger/lib/chopper_error_log.dart
+++ b/packages/talker_chopper_logger/lib/chopper_error_log.dart
@@ -1,5 +1,3 @@
-import 'dart:convert' show JsonEncoder;
-
 import 'package:chopper/chopper.dart'
     show ChopperException, ChopperHttpException, Request;
 import 'package:meta/meta.dart' show visibleForTesting;
@@ -16,8 +14,6 @@ class ChopperErrorLog<BodyType> extends TalkerLog {
     super.stackTrace,
   });
 
-  static const JsonEncoder _encoder = JsonEncoder.withIndent('  ');
-
   final Request? request;
   final TalkerChopperLoggerSettings settings;
   final int responseTime;
@@ -32,7 +28,7 @@ class ChopperErrorLog<BodyType> extends TalkerLog {
   LogLevel get logLevel => LogLevel.error;
 
   @visibleForTesting
-  String convert(Object? object) => _encoder.convert(object);
+  String convert(Object? object) => settings.jsonFormatter.format(object);
 
   @override
   String generateTextMessage({

--- a/packages/talker_chopper_logger/lib/chopper_request_log.dart
+++ b/packages/talker_chopper_logger/lib/chopper_request_log.dart
@@ -1,4 +1,4 @@
-import 'dart:convert' show JsonEncoder, jsonDecode;
+import 'dart:convert' show jsonDecode;
 
 import 'package:chopper/chopper.dart' show Request;
 import 'package:http/http.dart' as http
@@ -18,7 +18,6 @@ class ChopperRequestLog extends TalkerLog {
   final http.BaseRequest request;
   final TalkerChopperLoggerSettings settings;
 
-  static const JsonEncoder _encoder = JsonEncoder.withIndent('  ');
   static const String _hiddenValue = '*****';
 
   @override
@@ -31,7 +30,7 @@ class ChopperRequestLog extends TalkerLog {
   LogLevel get logLevel => settings.logLevel;
 
   @visibleForTesting
-  String convert(Object? object) => _encoder.convert(object);
+  String convert(Object? object) => settings.jsonFormatter.format(object);
 
   @override
   String generateTextMessage({

--- a/packages/talker_chopper_logger/lib/chopper_response_log.dart
+++ b/packages/talker_chopper_logger/lib/chopper_response_log.dart
@@ -1,5 +1,3 @@
-import 'dart:convert' show JsonEncoder;
-
 import 'package:chopper/chopper.dart' show Request, Response;
 import 'package:meta/meta.dart' show visibleForTesting;
 import 'package:talker/talker.dart';
@@ -19,8 +17,6 @@ class ChopperResponseLog<BodyType> extends TalkerLog {
   final TalkerChopperLoggerSettings settings;
   final int responseTime;
 
-  static const JsonEncoder _encoder = JsonEncoder.withIndent('  ');
-
   @override
   AnsiPen get pen => settings.responsePen ?? (AnsiPen()..xterm(46));
 
@@ -31,7 +27,7 @@ class ChopperResponseLog<BodyType> extends TalkerLog {
   LogLevel get logLevel => settings.logLevel;
 
   @visibleForTesting
-  String convert(Object? object) => _encoder.convert(object);
+  String convert(Object? object) => settings.jsonFormatter.format(object);
 
   @override
   String generateTextMessage({

--- a/packages/talker_chopper_logger/lib/talker_chopper_logger_settings.dart
+++ b/packages/talker_chopper_logger/lib/talker_chopper_logger_settings.dart
@@ -1,6 +1,6 @@
 import 'package:chopper/chopper.dart' show Response, Request;
 import 'package:equatable/equatable.dart';
-import 'package:talker/talker.dart' show AnsiPen, LogLevel;
+import 'package:talker/talker.dart' show AnsiPen, LogLevel, TalkerJsonFormatter;
 
 typedef RequestFilter = bool Function(Request request);
 typedef ResponseFilter = bool Function(Response response);
@@ -21,6 +21,7 @@ class TalkerChopperLoggerSettings with EquatableMixin {
     this.printRequestHeaders = false,
     this.printRequestCurl = false,
     this.hiddenHeaders = const <String>{},
+    this.jsonFormatter = const TalkerJsonFormatter(),
     this.requestPen,
     this.responsePen,
     this.errorPen,
@@ -117,6 +118,12 @@ class TalkerChopperLoggerSettings with EquatableMixin {
   /// Case insensitive
   final Set<String> hiddenHeaders;
 
+  /// JSON formatter for converting data to pretty string.
+  /// Use [TalkerJsonFormatter] for default formatting,
+  /// [TalkerJsonFormatter(stripQuotes: true)] to strip quotes,
+  /// or [TalkerJsonFormatter.custom(fn)] for custom formatting.
+  final TalkerJsonFormatter jsonFormatter;
+
   TalkerChopperLoggerSettings copyWith({
     bool? enabled,
     LogLevel? logLevel,
@@ -137,6 +144,7 @@ class TalkerChopperLoggerSettings with EquatableMixin {
     ResponseFilter? responseFilter,
     ResponseFilter? errorFilter,
     Set<String>? hiddenHeaders,
+    TalkerJsonFormatter? jsonFormatter,
   }) =>
       TalkerChopperLoggerSettings(
         enabled: enabled ?? this.enabled,
@@ -158,6 +166,7 @@ class TalkerChopperLoggerSettings with EquatableMixin {
         responseFilter: responseFilter ?? this.responseFilter,
         errorFilter: errorFilter ?? this.errorFilter,
         hiddenHeaders: hiddenHeaders ?? this.hiddenHeaders,
+        jsonFormatter: jsonFormatter ?? this.jsonFormatter,
       );
 
   @override
@@ -180,5 +189,6 @@ class TalkerChopperLoggerSettings with EquatableMixin {
         responseFilter,
         errorFilter,
         hiddenHeaders,
+        jsonFormatter,
       ];
 }

--- a/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
+++ b/packages/talker_dio_logger/lib/talker_dio_logger_settings.dart
@@ -18,8 +18,7 @@ class TalkerDioLoggerSettings {
     this.printRequestHeaders = false,
     this.printRequestExtra = false,
     this.hiddenHeaders = const <String>{},
-    this.stripJsonQuotes = false,
-    this.prettyFormatter,
+    this.jsonFormatter = const TalkerJsonFormatter(),
     this.responseDataConverter,
     this.requestPen,
     this.responsePen,
@@ -109,13 +108,11 @@ class TalkerDioLoggerSettings {
   /// You can add your custom logic to log only specific HTTP responses [Response].
   final bool Function(Response response)? responseFilter;
 
-  /// Strip double quotes from JSON output.
-  /// Only applies when using default encoder (no prettyFormatter is set).
-  final bool stripJsonQuotes;
-
-  /// Custom formatter for converting data to pretty string.
-  /// If null, uses default JsonEncoder with indent.
-  final String Function(dynamic data)? prettyFormatter;
+  /// JSON formatter for converting data to pretty string.
+  /// Use [TalkerJsonFormatter] for default formatting,
+  /// [TalkerJsonFormatter(stripQuotes: true)] to strip quotes,
+  /// or [TalkerJsonFormatter.custom(fn)] for custom formatting.
+  final TalkerJsonFormatter jsonFormatter;
 
   /// Response data converter.
   final String Function(Response response)? responseDataConverter;
@@ -144,8 +141,7 @@ class TalkerDioLoggerSettings {
     AnsiPen? errorPen,
     bool Function(RequestOptions requestOptions)? requestFilter,
     bool Function(Response response)? responseFilter,
-    bool? stripJsonQuotes,
-    String Function(dynamic data)? prettyFormatter,
+    TalkerJsonFormatter? jsonFormatter,
     String Function(Response response)? responseDataConverter,
     bool Function(DioException response)? errorFilter,
     Set<String>? hiddenHeaders,
@@ -167,8 +163,7 @@ class TalkerDioLoggerSettings {
       errorPen: errorPen ?? this.errorPen,
       requestFilter: requestFilter ?? this.requestFilter,
       responseFilter: responseFilter ?? this.responseFilter,
-      stripJsonQuotes: stripJsonQuotes ?? this.stripJsonQuotes,
-      prettyFormatter: prettyFormatter ?? this.prettyFormatter,
+      jsonFormatter: jsonFormatter ?? this.jsonFormatter,
       responseDataConverter:
           responseDataConverter ?? this.responseDataConverter,
       errorFilter: errorFilter ?? this.errorFilter,

--- a/packages/talker_http_logger/lib/http_error_log.dart
+++ b/packages/talker_http_logger/lib/http_error_log.dart
@@ -1,4 +1,4 @@
-import 'dart:convert' show JsonEncoder, jsonDecode;
+import 'dart:convert' show jsonDecode;
 
 import 'package:http_interceptor/http_interceptor.dart';
 import 'package:meta/meta.dart';
@@ -20,8 +20,6 @@ class HttpErrorLog extends TalkerLog with ResponseTime {
   final BaseResponse? response;
   final TalkerHttpLoggerSettings settings;
 
-  static const JsonEncoder _encoder = JsonEncoder.withIndent('  ');
-
   @override
   AnsiPen get pen => settings.errorPen ?? (AnsiPen()..red());
 
@@ -32,7 +30,7 @@ class HttpErrorLog extends TalkerLog with ResponseTime {
   LogLevel get logLevel => LogLevel.error;
 
   @visibleForTesting
-  String convert(Object? object) => _encoder.convert(object);
+  String convert(Object? object) => settings.jsonFormatter.format(object);
 
   @override
   String generateTextMessage({

--- a/packages/talker_http_logger/lib/http_request_log.dart
+++ b/packages/talker_http_logger/lib/http_request_log.dart
@@ -1,4 +1,4 @@
-import 'dart:convert' show JsonEncoder, jsonDecode;
+import 'dart:convert' show jsonDecode;
 
 import 'package:http_interceptor/http_interceptor.dart';
 import 'package:meta/meta.dart';
@@ -16,7 +16,6 @@ class HttpRequestLog extends TalkerLog {
   final BaseRequest request;
   final TalkerHttpLoggerSettings settings;
 
-  static const JsonEncoder _encoder = JsonEncoder.withIndent('  ');
   static const String _hiddenValue = '*****';
 
   @override
@@ -29,7 +28,7 @@ class HttpRequestLog extends TalkerLog {
   LogLevel get logLevel => settings.logLevel;
 
   @visibleForTesting
-  String convert(Object? object) => _encoder.convert(object);
+  String convert(Object? object) => settings.jsonFormatter.format(object);
 
   @override
   String generateTextMessage({

--- a/packages/talker_http_logger/lib/http_response_log.dart
+++ b/packages/talker_http_logger/lib/http_response_log.dart
@@ -1,4 +1,4 @@
-import 'dart:convert' show JsonEncoder, jsonDecode;
+import 'dart:convert' show jsonDecode;
 
 import 'package:http_interceptor/http_interceptor.dart';
 import 'package:meta/meta.dart';
@@ -16,8 +16,6 @@ class HttpResponseLog extends TalkerLog with ResponseTime {
   final BaseResponse response;
   final TalkerHttpLoggerSettings settings;
 
-  static const JsonEncoder _encoder = JsonEncoder.withIndent('  ');
-
   @override
   AnsiPen get pen => settings.responsePen ?? (AnsiPen()..xterm(46));
 
@@ -28,7 +26,7 @@ class HttpResponseLog extends TalkerLog with ResponseTime {
   LogLevel get logLevel => settings.logLevel;
 
   @visibleForTesting
-  String convert(Object? object) => _encoder.convert(object);
+  String convert(Object? object) => settings.jsonFormatter.format(object);
 
   @override
   String generateTextMessage({

--- a/packages/talker_http_logger/lib/talker_http_logger_settings.dart
+++ b/packages/talker_http_logger/lib/talker_http_logger_settings.dart
@@ -23,6 +23,7 @@ class TalkerHttpLoggerSettings with EquatableMixin {
     this.printRequestHeaders = false,
     this.printRequestCurl = false,
     this.hiddenHeaders = const <String>{},
+    this.jsonFormatter = const TalkerJsonFormatter(),
     this.requestPen,
     this.responsePen,
     this.errorPen,
@@ -119,6 +120,12 @@ class TalkerHttpLoggerSettings with EquatableMixin {
   /// Case insensitive
   final Set<String> hiddenHeaders;
 
+  /// JSON formatter for converting data to pretty string.
+  /// Use [TalkerJsonFormatter] for default formatting,
+  /// [TalkerJsonFormatter(stripQuotes: true)] to strip quotes,
+  /// or [TalkerJsonFormatter.custom(fn)] for custom formatting.
+  final TalkerJsonFormatter jsonFormatter;
+
   TalkerHttpLoggerSettings copyWith({
     bool? enabled,
     LogLevel? logLevel,
@@ -139,6 +146,7 @@ class TalkerHttpLoggerSettings with EquatableMixin {
     ResponseFilter? responseFilter,
     ResponseFilter? errorFilter,
     Set<String>? hiddenHeaders,
+    TalkerJsonFormatter? jsonFormatter,
   }) =>
       TalkerHttpLoggerSettings(
         enabled: enabled ?? this.enabled,
@@ -160,6 +168,7 @@ class TalkerHttpLoggerSettings with EquatableMixin {
         responseFilter: responseFilter ?? this.responseFilter,
         errorFilter: errorFilter ?? this.errorFilter,
         hiddenHeaders: hiddenHeaders ?? this.hiddenHeaders,
+        jsonFormatter: jsonFormatter ?? this.jsonFormatter,
       );
 
   @override
@@ -182,5 +191,6 @@ class TalkerHttpLoggerSettings with EquatableMixin {
         responseFilter,
         errorFilter,
         hiddenHeaders,
+        jsonFormatter,
       ];
 }


### PR DESCRIPTION
Summary
- Add prettyFormatter setting to customize data formatting (that overrides default JsonEncoder)
- Add stripJsonQuotes setting to strip double quotes from JSON output while preserving escaped quotes in values

Example
```dart
TalkerDioLogger(
  settings: TalkerDioLoggerSettings(
    stripJsonQuotes: true,
  ),
)
```

```
Before:
{
  "name": "John \"Doe\"",
  "age": 30
}

After:
{
  name: John "Doe",
  age: 30
}
```

## Summary by Sourcery

Introduce customizable pretty-printing for Dio logs and an option to strip JSON quotes from default-formatted output.

New Features:
- Add a configurable prettyFormatter callback on TalkerDioLoggerSettings to customize how request, response, and error data are rendered in logs.
- Add a stripJsonQuotes flag on TalkerDioLoggerSettings to remove double quotes from JSON output when using the default formatter.

Enhancements:
- Centralize log data formatting through a shared helper to ensure consistent handling of data, headers, and extras across request, response, and error logs.