### PR TITLE
chore(talker_flutter): bump share_plus from ^12.0.1 to ^13.0.0

### DIFF
--- a/packages/talker_flutter/pubspec.yaml
+++ b/packages/talker_flutter/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   talker: ^5.1.16
   group_button: ^5.3.4
   path_provider: ^2.1.4
-  share_plus: ^12.0.1
+  share_plus: ^13.0.0
   web: ^1.1.0
 
 


### PR DESCRIPTION
## Summary

Bump `share_plus` in `packages/talker_flutter/pubspec.yaml` from `^12.0.1` to `^13.0.0`.

## Motivation

The 12.x constraint blocks downstream packages that need `wakelock_plus ^1.6.0`, `device_info_plus ^13.x`, or any other package that has moved to `win32 ^6.0.0`. `share_plus 12.x` still holds `win32 ^5.5.3`, creating an unresolvable version conflict.

## API compatibility

The only `share_plus` usage in `talker_flutter` is in [`packages/talker_flutter/lib/src/utils/download_logs/download_logs_native.dart`](https://github.com/Frezyx/talker/blob/master/packages/talker_flutter/lib/src/utils/download_logs/download_logs_native.dart):

```dart
await SharePlus.instance.share(
  ShareParams(files: <XFile>[XFile(file.path)]),
);
```

This API (`SharePlus.instance.share(ShareParams)`) was introduced in `share_plus 11.0.0` and is unchanged in 13.x. No code changes required.

## What 13.x brings

Per the [`share_plus` CHANGELOG](https://github.com/fluttercommunity/plus_plugins/blob/main/packages/share_plus/share_plus/CHANGELOG.md):
- `13.0.0`: bumps `win32` 5→6, requires Flutter ≥ 3.41.6 / Dart ≥ 3.11.0, iOS ≥ 13.0, macOS ≥ 10.15
- `13.1.0`: lowers to Flutter ≥ 3.38.1 / Dart ≥ 3.10

The `talker_flutter` environment is already `sdk: '>=3.6.0 <4.0.0'`, `flutter: '>=1.17.0'` — downstream consumers who need 13.x will constrain Flutter themselves; this PR just unblocks them at the `share_plus` layer.

## Test plan

- [x] `share_plus 13.1.0` resolves against the package.
- [x] `SharePlus.instance.share(ShareParams)` signature unchanged — no source changes.
- [ ] `example/` app builds (maintainer to verify in CI — no source changes to example either).

## Summary by Sourcery

Enhancements:
- Relax share_plus version constraint in talker_flutter to align with ecosystem packages depending on win32 6.x.