### PR TITLE
add support for logging streamed data in http_logger

### DIFF
--- a/packages/talker_http_logger/example/pubspec.yaml
+++ b/packages/talker_http_logger/example/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   equatable: ^2.0.7
 
 dev_dependencies:
-  flutter_lints: ^5.1.1
+  flutter_lints: ^6.0.0
 
 dependency_overrides:
   talker_http_logger:

--- a/packages/talker_http_logger/lib/talker_http_logger_interceptor.dart
+++ b/packages/talker_http_logger/lib/talker_http_logger_interceptor.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:http_interceptor/http_interceptor.dart';
 import 'package:talker/talker.dart';
 import 'package:talker_http_logger/http_error_log.dart';
@@ -103,25 +105,56 @@ class TalkerHttpLogger extends InterceptorContract {
   }) async {
     final String message = '${response.request?.url}';
 
-    switch (response.statusCode) {
+    BaseResponse resForTalker;
+    BaseResponse resForReturn;
+
+    if (response is StreamedResponse) {
+      final bytes = await response.stream.toBytes();
+      final body = utf8.decode(bytes);
+      resForTalker = Response(
+        body,
+        response.statusCode,
+        headers: response.headers,
+        isRedirect: response.isRedirect,
+        persistentConnection: response.persistentConnection,
+        reasonPhrase: response.reasonPhrase,
+        request: response.request,
+      );
+
+      resForReturn = StreamedResponse(
+        Stream.value(bytes),
+        response.statusCode,
+        headers: response.headers,
+        isRedirect: response.isRedirect,
+        persistentConnection: response.persistentConnection,
+        reasonPhrase: response.reasonPhrase,
+        request: response.request,
+        contentLength: bytes.length,
+      );
+    } else {
+      resForTalker = response;
+      resForReturn = response;
+    }
+
+    switch (resForTalker.statusCode) {
       case int statusCode when settings.enabled && statusCode < 400:
-        if (settings.responseFilter?.call(response) ?? true) {
+        if (settings.responseFilter?.call(resForTalker) ?? true) {
           _talker.logCustom(
             HttpResponseLog(
               message,
-              response: response,
+              response: resForTalker,
               settings: settings,
             ),
           );
         }
         break;
       case _ when settings.enabled:
-        if (settings.errorFilter?.call(response) ?? true) {
+        if (settings.errorFilter?.call(resForTalker) ?? true) {
           _talker.logCustom(
             HttpErrorLog(
               message,
-              request: response.request,
-              response: response,
+              request: resForTalker.request,
+              response: resForTalker,
               settings: settings,
             ),
           );
@@ -129,6 +162,6 @@ class TalkerHttpLogger extends InterceptorContract {
         break;
     }
 
-    return response;
+    return resForReturn;
   }
 }


### PR DESCRIPTION
First of all, this may not be the best way to implement this, i created a PR instead of creating this as an issue because you may get better context of what the feature is about. that being said, i am open to make any changes to this PR.

Thanks for the amazing SDK

## Summary by Sourcery

Add support for logging HTTP streamed responses while preserving the original response stream behavior.

New Features:
- Enable logging of StreamedResponse HTTP responses by reading and decoding the response stream for Talker logging.

Enhancements:
- Ensure logged HTTP responses and returned responses are decoupled so logging does not consume or alter the original response stream.

Build:
- Update example package dev dependency to flutter_lints ^6.0.0.